### PR TITLE
Fix testing scope failures when not testing

### DIFF
--- a/src/scope.js
+++ b/src/scope.js
@@ -15,3 +15,5 @@
 var shared = {};
 var minifill = {};
 var maxifill = {};
+if (!TESTING)
+  var testing = null;

--- a/web-animations.js
+++ b/web-animations.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 var global = this;
-if (TESTING === undefined) {
+if (window.TESTING === undefined) {
   var TESTING = false;
 }
 


### PR DESCRIPTION
Ensure testing is defined when using web-animations.js outside of testing.
