### PR TITLE
Enable linting of indentation and fix style errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,9 +31,10 @@ module.exports = function(grunt) {
       options: {
         flags: [
           '--nojsdoc',
-          '--nostrict',
-          '--disable 121,110', // 121: Illegal comma at end of object literal
-                               // 110: Line too long
+          '--strict',
+          '--disable 7,121,110', //   7: Wrong blank line count
+                                 // 121: Illegal comma at end of object literal
+                                 // 110: Line too long
         ],
         reporter: {
           name: 'console'

--- a/src/color-handler.js
+++ b/src/color-handler.js
@@ -40,9 +40,10 @@
       function clamp(v) {
         return Math.max(0, Math.min(255, v));
       }
-      if (x[3])
+      if (x[3]) {
         for (var i = 0; i < 3; i++)
           x[i] = Math.round(clamp(x[i] / x[3]));
+      }
       x[3] = scope.numberToString(clamp(x[3]));
       return 'rgba(' + x.join(',') + ')';
     }];

--- a/src/dimension-handler.js
+++ b/src/dimension-handler.js
@@ -66,9 +66,10 @@
     var units = [], unit;
     for (unit in left)
       units.push(unit);
-    for (unit in right)
+    for (unit in right) {
       if (units.indexOf(unit) < 0)
         units.push(unit);
+    }
 
     left = units.map(function(unit) { return left[unit] || 0; });
     right = units.map(function(unit) { return right[unit] || 0; });
@@ -92,6 +93,6 @@
   scope.mergeDimensions = mergeDimensions;
 
   scope.addPropertiesHandler(parseLengthOrPercent, mergeDimensions,
-    'left|right|top|bottom|width|height'.split('|'));
+      'left|right|top|bottom|width|height'.split('|'));
 
 })(minifill, testing);

--- a/src/effect.js
+++ b/src/effect.js
@@ -25,23 +25,24 @@
     var interpolations = makeInterpolations(propertySpecificKeyframeGroups);
     return function(target, fraction) {
       if (fraction != null) {
-        for (var i = 0; i < interpolations.length && interpolations[i].startTime <= fraction; i++)
+        for (var i = 0; i < interpolations.length && interpolations[i].startTime <= fraction; i++) {
           if (interpolations[i].endTime >= fraction && interpolations[i].endTime != interpolations[i].startTime)
             scope.apply(target,
-              interpolations[i].property,
-              interpolations[i].interpolation((fraction - interpolations[i].startTime) / (interpolations[i].endTime - interpolations[i].startTime)));
-        } else {
-          for (var property in propertySpecificKeyframeGroups)
-            if (property != 'offset')
-              scope.clear(target, property);
+                interpolations[i].property,
+                interpolations[i].interpolation((fraction - interpolations[i].startTime) / (interpolations[i].endTime - interpolations[i].startTime)));
         }
+      } else {
+        for (var property in propertySpecificKeyframeGroups)
+          if (property != 'offset')
+            scope.clear(target, property);
+      }
     };
   };
 
 
   function normalize(effectInput) {
     if (!Array.isArray(effectInput) && effectInput !== null)
-        throw new TypeError('Keyframe effect must be null or an array of keyframes');
+      throw new TypeError('Keyframe effect must be null or an array of keyframes');
 
     if (effectInput == null)
       return [];
@@ -88,10 +89,9 @@
       if (!everyFrameHasOffset) {
         throw 'Keyframes are not loosely sorted by offset. Sort or specify offsets.';
       }
-      keyframeEffect.sort(
-        function(leftKeyframe, rightKeyframe) {
-          return leftKeyframe.offset - rightKeyframe.offset;
-        });
+      keyframeEffect.sort(function(leftKeyframe, rightKeyframe) {
+        return leftKeyframe.offset - rightKeyframe.offset;
+      });
     }
 
     function spaceKeyframes() {
@@ -159,10 +159,9 @@
         });
       }
     }
-    interpolations.sort(
-      function(leftInterpolation, rightInterpolation) {
-        return leftInterpolation.startTime - rightInterpolation.startTime;
-      });
+    interpolations.sort(function(leftInterpolation, rightInterpolation) {
+      return leftInterpolation.startTime - rightInterpolation.startTime;
+    });
     return interpolations;
   }
 

--- a/test/js/effect.js
+++ b/test/js/effect.js
@@ -1,380 +1,332 @@
 suite('effect', function() {
   // Test normalize.
-  test('Normalize keyframes with all offsets specified but not sorted by offset. Some offsets are out of [0, 1] range.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize(
-          [
-          {offset: 0},
-          {offset: -1},
-          {offset: 1},
-          {offset: 0.5},
-          {offset: 2}
-          ]);
-      });
-      assert.equal(normalizedKeyframes.length, 3);
-      assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
-      assert.closeTo(normalizedKeyframes[1].offset, 0.5, 0.001);
-      assert.closeTo(normalizedKeyframes[2].offset, 1, 0.001);
+  test('Normalize keyframes with all offsets specified but not sorted by offset. Some offsets are out of [0, 1] range.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize([
+        {offset: 0},
+        {offset: -1},
+        {offset: 1},
+        {offset: 0.5},
+        {offset: 2}
+      ]);
     });
+    assert.equal(normalizedKeyframes.length, 3);
+    assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
+    assert.closeTo(normalizedKeyframes[1].offset, 0.5, 0.001);
+    assert.closeTo(normalizedKeyframes[2].offset, 1, 0.001);
+  });
 
-  test('Normalize keyframes with some offsets not specified, and not sorted by offset.',
-    function() {
-      assert.throws(function() {
-        normalize(
-          [
-          {offset: 0.5},
-          {offset: 0},
-          {offset: 0.8},
-          {},
-          {offset: 1}
-          ]);
-      });
+  test('Normalize keyframes with some offsets not specified, and not sorted by offset.', function() {
+    assert.throws(function() {
+      normalize([
+        {offset: 0.5},
+        {offset: 0},
+        {offset: 0.8},
+        {},
+        {offset: 1}
+      ]);
     });
+  });
 
-  test('Normalize keyframes with some offsets not specified, and not sorted by offset. Out of order keyframes are out of [0, 1] range.',
-    function() {
-      assert.throws(function() {
-        normalize(
-          [
-          {offset: 0},
-          {offset: -1},
-          {offset: 0.5},
-          {},
-          {offset: 1}
-          ]);
-      });
+  test('Normalize keyframes with some offsets not specified, and not sorted by offset. Out of order keyframes are out of [0, 1] range.', function() {
+    assert.throws(function() {
+      normalize([
+        {offset: 0},
+        {offset: -1},
+        {offset: 0.5},
+        {},
+        {offset: 1}
+      ]);
     });
+  });
 
-  test('Normalize keyframes with some offsets not specified, but sorted by offset where specified. Some offsets are out of [0, 1] range.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize(
-          [
-          {offset: -1},
-          {offset: 0},
-          {offset: 0.5},
-          {},
-          {},
-          {offset: 2}
-          ]);
-      });
-      assert.equal(normalizedKeyframes.length, 4);
-      assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
-      assert.closeTo(normalizedKeyframes[1].offset, 0.5, 0.001);
-      assert.closeTo(normalizedKeyframes[2].offset, 0.75, 0.001);
-      assert.closeTo(normalizedKeyframes[3].offset, 1, 0.001);
+  test('Normalize keyframes with some offsets not specified, but sorted by offset where specified. Some offsets are out of [0, 1] range.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize([
+        {offset: -1},
+        {offset: 0},
+        {offset: 0.5},
+        {},
+        {},
+        {offset: 2}
+      ]);
     });
+    assert.equal(normalizedKeyframes.length, 4);
+    assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
+    assert.closeTo(normalizedKeyframes[1].offset, 0.5, 0.001);
+    assert.closeTo(normalizedKeyframes[2].offset, 0.75, 0.001);
+    assert.closeTo(normalizedKeyframes[3].offset, 1, 0.001);
+  });
 
-  test('Normalize keyframes with some offsets not specified, but sorted by offset where specified. All specified offsets in [0, 1] range.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize(
-          [
-          {left: '0px', offset: 0},
-          {left: '10px'},
-          {left: '20px'},
-          {left: '30px', offset: 0.6},
-          {left: '40px'},
-          {left: '50px'}
-          ]);
-      });
-      assert.equal(normalizedKeyframes.length, 6);
-      assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
-      assert.equal(normalizedKeyframes[0].left, '0px');
-      assert.closeTo(normalizedKeyframes[1].offset, 0.2, 0.001);
-      assert.equal(normalizedKeyframes[1].left, '10px');
-      assert.closeTo(normalizedKeyframes[2].offset, 0.4, 0.001);
-      assert.equal(normalizedKeyframes[2].left, '20px');
-      assert.closeTo(normalizedKeyframes[3].offset, 0.6, 0.001);
-      assert.equal(normalizedKeyframes[3].left, '30px');
-      assert.closeTo(normalizedKeyframes[4].offset, 0.8, 0.001);
-      assert.equal(normalizedKeyframes[4].left, '40px');
-      assert.closeTo(normalizedKeyframes[5].offset, 1, 0.001);
-      assert.equal(normalizedKeyframes[5].left, '50px');
+  test('Normalize keyframes with some offsets not specified, but sorted by offset where specified. All specified offsets in [0, 1] range.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize([
+        {left: '0px', offset: 0},
+        {left: '10px'},
+        {left: '20px'},
+        {left: '30px', offset: 0.6},
+        {left: '40px'},
+        {left: '50px'}
+      ]);
     });
+    assert.equal(normalizedKeyframes.length, 6);
+    assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
+    assert.equal(normalizedKeyframes[0].left, '0px');
+    assert.closeTo(normalizedKeyframes[1].offset, 0.2, 0.001);
+    assert.equal(normalizedKeyframes[1].left, '10px');
+    assert.closeTo(normalizedKeyframes[2].offset, 0.4, 0.001);
+    assert.equal(normalizedKeyframes[2].left, '20px');
+    assert.closeTo(normalizedKeyframes[3].offset, 0.6, 0.001);
+    assert.equal(normalizedKeyframes[3].left, '30px');
+    assert.closeTo(normalizedKeyframes[4].offset, 0.8, 0.001);
+    assert.equal(normalizedKeyframes[4].left, '40px');
+    assert.closeTo(normalizedKeyframes[5].offset, 1, 0.001);
+    assert.equal(normalizedKeyframes[5].left, '50px');
+  });
 
-  test('Normalize keyframes with no offsets specified.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize(
-          [
-          {left: '0px'},
-          {left: '10px'},
-          {left: '20px'},
-          {left: '30px'},
-          {left: '40px'}
-          ]);
-      });
-      assert.equal(normalizedKeyframes.length, 5);
-      assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
-      assert.equal(normalizedKeyframes[0].left, '0px');
-      assert.closeTo(normalizedKeyframes[1].offset, 0.25, 0.001);
-      assert.equal(normalizedKeyframes[1].left, '10px');
-      assert.closeTo(normalizedKeyframes[2].offset, 0.5, 0.001);
-      assert.equal(normalizedKeyframes[2].left, '20px');
-      assert.closeTo(normalizedKeyframes[3].offset, 0.75, 0.001);
-      assert.equal(normalizedKeyframes[3].left, '30px');
-      assert.closeTo(normalizedKeyframes[4].offset, 1, 0.001);
-      assert.equal(normalizedKeyframes[4].left, '40px');
+  test('Normalize keyframes with no offsets specified.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize([
+        {left: '0px'},
+        {left: '10px'},
+        {left: '20px'},
+        {left: '30px'},
+        {left: '40px'}
+      ]);
     });
+    assert.equal(normalizedKeyframes.length, 5);
+    assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
+    assert.equal(normalizedKeyframes[0].left, '0px');
+    assert.closeTo(normalizedKeyframes[1].offset, 0.25, 0.001);
+    assert.equal(normalizedKeyframes[1].left, '10px');
+    assert.closeTo(normalizedKeyframes[2].offset, 0.5, 0.001);
+    assert.equal(normalizedKeyframes[2].left, '20px');
+    assert.closeTo(normalizedKeyframes[3].offset, 0.75, 0.001);
+    assert.equal(normalizedKeyframes[3].left, '30px');
+    assert.closeTo(normalizedKeyframes[4].offset, 1, 0.001);
+    assert.equal(normalizedKeyframes[4].left, '40px');
+  });
 
-  test('Normalize keyframes where a keyframe has an offset that is not a number.',
-    function() {
-      assert.throws(function() {
-        normalize(
-          [
-          {offset: 0},
-          {offset: 'one'},
-          {offset: 1}
-          ]);
-      });
+  test('Normalize keyframes where a keyframe has an offset that is not a number.', function() {
+    assert.throws(function() {
+      normalize([
+        {offset: 0},
+        {offset: 'one'},
+        {offset: 1}
+      ]);
     });
+  });
 
-  test('Normalize keyframes where a keyframe has an offset that is a numeric string.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize(
-          [
-          {offset: 0},
-          {offset: '0.5'},
-          {offset: 1}
-          ]);
-      });
-      assert.equal(normalizedKeyframes.length, 3);
-      assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
-      assert.closeTo(normalizedKeyframes[1].offset, 0.5, 0.001);
-      assert.closeTo(normalizedKeyframes[2].offset, 1, 0.001);
+  test('Normalize keyframes where a keyframe has an offset that is a numeric string.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize([
+        {offset: 0},
+        {offset: '0.5'},
+        {offset: 1}
+      ]);
     });
+    assert.equal(normalizedKeyframes.length, 3);
+    assert.closeTo(normalizedKeyframes[0].offset, 0, 0.001);
+    assert.closeTo(normalizedKeyframes[1].offset, 0.5, 0.001);
+    assert.closeTo(normalizedKeyframes[2].offset, 1, 0.001);
+  });
 
-  test('Normalize keyframes where some properties are given non-string, non-number values.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize(
-          [
-          {left: {}},
-          {left: '100px'},
-          {left: []}
-          ]);
-      });
-      assert(normalizedKeyframes.length, 3);
-      assert.equal(normalizedKeyframes[0].left, '[object Object]');
-      assert.equal(normalizedKeyframes[1].left, '100px');
-      assert.equal(normalizedKeyframes[2].left, '');
+  test('Normalize keyframes where some properties are given non-string, non-number values.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize([
+        {left: {}},
+        {left: '100px'},
+        {left: []}
+      ]);
     });
+    assert(normalizedKeyframes.length, 3);
+    assert.equal(normalizedKeyframes[0].left, '[object Object]');
+    assert.equal(normalizedKeyframes[1].left, '100px');
+    assert.equal(normalizedKeyframes[2].left, '');
+  });
 
-  test('Normalize input that is not an array.',
-    function() {
-      assert.throws(function() {
-        normalize(10);
-      });
+  test('Normalize input that is not an array.', function() {
+    assert.throws(function() {
+      normalize(10);
     });
+  });
 
-  test('Normalize an empty array.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize([]);
-      });
-      assert.deepEqual(normalizedKeyframes, []);
+  test('Normalize an empty array.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize([]);
     });
+    assert.deepEqual(normalizedKeyframes, []);
+  });
 
-  test('Normalize null.',
-    function() {
-      var normalizedKeyframes;
-      assert.doesNotThrow(function() {
-        normalizedKeyframes = normalize(null);
-      });
-      assert.deepEqual(normalizedKeyframes, []);
+  test('Normalize null.', function() {
+    var normalizedKeyframes;
+    assert.doesNotThrow(function() {
+      normalizedKeyframes = normalize(null);
     });
+    assert.deepEqual(normalizedKeyframes, []);
+  });
 
   // Test makePropertySpecificKeyframeGroups.
-  test('Make property specific keyframe groups for a simple effect with one property.',
-    function() {
-      var groups;
-      assert.doesNotThrow(function() {
-        groups = makePropertySpecificKeyframeGroups(normalize(
-          [
-          {left: '0px'},
-          {left: '200px', offset: 0.3},
-          {left: '0px'}
-          ])
-        );
-      });
-      assert.equal(Object.getOwnPropertyNames(groups).length, 1);
-      assert.equal(groups.left.length, 3);
-      assert.closeTo(groups.left[0].offset, 0, 0.001);
-      assert.equal(groups.left[0].value, '0px');
-      assert.closeTo(groups.left[1].offset, 0.3, 0.001);
-      assert.equal(groups.left[1].value, '200px');
-      assert.closeTo(groups.left[2].offset, 1, 0.001);
-      assert.equal(groups.left[2].value, '0px');
+  test('Make property specific keyframe groups for a simple effect with one property.', function() {
+    var groups;
+    assert.doesNotThrow(function() {
+      groups = makePropertySpecificKeyframeGroups(normalize([
+        {left: '0px'},
+        {left: '200px', offset: 0.3},
+        {left: '0px'}
+      ]));
     });
+    assert.equal(Object.getOwnPropertyNames(groups).length, 1);
+    assert.equal(groups.left.length, 3);
+    assert.closeTo(groups.left[0].offset, 0, 0.001);
+    assert.equal(groups.left[0].value, '0px');
+    assert.closeTo(groups.left[1].offset, 0.3, 0.001);
+    assert.equal(groups.left[1].value, '200px');
+    assert.closeTo(groups.left[2].offset, 1, 0.001);
+    assert.equal(groups.left[2].value, '0px');
+  });
 
-  test('Make property specific keyframe groups for an effect with three properties.',
-    function() {
-      var groups;
-      assert.doesNotThrow(function() {
-        groups = makePropertySpecificKeyframeGroups(normalize(
-          [
-          {left: '0px', top: '200px', opacity: 1},
-          {left: '200px', top: '0px'},
-          {left: '0px', top: '200px', opacity: 0},
-          {top: '0px', opacity: 1},
-          {left: '200px', top: '200px', opacity: 0}
-          ])
-        );
-      });
-      assert.equal(Object.getOwnPropertyNames(groups).length, 3);
-
-      assert.equal(groups.left.length, 4);
-      assert.closeTo(groups.left[0].offset, 0, 0.001);
-      assert.equal(groups.left[0].value, '0px');
-      assert.closeTo(groups.left[1].offset, 0.25, 0.001);
-      assert.equal(groups.left[1].value, '200px');
-      assert.closeTo(groups.left[2].offset, 0.5, 0.001);
-      assert.equal(groups.left[2].value, '0px');
-      assert.closeTo(groups.left[3].offset, 1, 0.001);
-      assert.equal(groups.left[3].value, '200px');
-
-      assert.equal(groups.top.length, 5);
-      assert.closeTo(groups.top[0].offset, 0, 0.001);
-      assert.equal(groups.top[0].value, '200px');
-      assert.closeTo(groups.top[1].offset, 0.25, 0.001);
-      assert.equal(groups.top[1].value, '0px');
-      assert.closeTo(groups.top[2].offset, 0.5, 0.001);
-      assert.equal(groups.top[2].value, '200px');
-      assert.closeTo(groups.top[3].offset, 0.75, 0.001);
-      assert.equal(groups.top[3].value, '0px');
-      assert.closeTo(groups.top[4].offset, 1, 0.001);
-      assert.equal(groups.top[4].value, '200px');
-
-      assert.equal(groups.opacity.length, 4);
-      assert.closeTo(groups.opacity[0].offset, 0, 0.001);
-      assert.equal(groups.opacity[0].value, 1);
-      assert.closeTo(groups.opacity[1].offset, 0.5, 0.001);
-      assert.equal(groups.opacity[1].value, 0);
-      assert.closeTo(groups.opacity[2].offset, 0.75, 0.001);
-      assert.equal(groups.opacity[2].value, 1);
-      assert.closeTo(groups.opacity[3].offset, 1, 0.001);
-      assert.equal(groups.opacity[3].value, 0);
+  test('Make property specific keyframe groups for an effect with three properties.', function() {
+    var groups;
+    assert.doesNotThrow(function() {
+      groups = makePropertySpecificKeyframeGroups(normalize([
+        {left: '0px', top: '200px', opacity: 1},
+        {left: '200px', top: '0px'},
+        {left: '0px', top: '200px', opacity: 0},
+        {top: '0px', opacity: 1},
+        {left: '200px', top: '200px', opacity: 0}
+      ]));
     });
+    assert.equal(Object.getOwnPropertyNames(groups).length, 3);
 
-  test('Make property specific keyframes when the offset of the last keyframe is specified but not equal to 1.',
-    function() {
-      assert.throws(function() {
-        makePropertySpecificKeyframeGroups(normalize(
-          [
-          {left: '0px', offset: 0},
-          {left: '20px'},
-          {left: '30px', offset: 0.9}
-          ])
-        );
-      });
-    });
+    assert.equal(groups.left.length, 4);
+    assert.closeTo(groups.left[0].offset, 0, 0.001);
+    assert.equal(groups.left[0].value, '0px');
+    assert.closeTo(groups.left[1].offset, 0.25, 0.001);
+    assert.equal(groups.left[1].value, '200px');
+    assert.closeTo(groups.left[2].offset, 0.5, 0.001);
+    assert.equal(groups.left[2].value, '0px');
+    assert.closeTo(groups.left[3].offset, 1, 0.001);
+    assert.equal(groups.left[3].value, '200px');
 
-  test('Make property specific keyframes when no properties are animated, and the offset of the last keyframe is specified but not equal to 1.',
-    function() {
-      var groups;
-      assert.doesNotThrow(function() {
-        groups = makePropertySpecificKeyframeGroups(normalize(
-          [
-          {offset: 0},
-          {},
-          {offset: 0.9}
-          ])
-        );
-      });
-      assert.equal(Object.getOwnPropertyNames(groups).length, 0);
-    });
+    assert.equal(groups.top.length, 5);
+    assert.closeTo(groups.top[0].offset, 0, 0.001);
+    assert.equal(groups.top[0].value, '200px');
+    assert.closeTo(groups.top[1].offset, 0.25, 0.001);
+    assert.equal(groups.top[1].value, '0px');
+    assert.closeTo(groups.top[2].offset, 0.5, 0.001);
+    assert.equal(groups.top[2].value, '200px');
+    assert.closeTo(groups.top[3].offset, 0.75, 0.001);
+    assert.equal(groups.top[3].value, '0px');
+    assert.closeTo(groups.top[4].offset, 1, 0.001);
+    assert.equal(groups.top[4].value, '200px');
 
-  test('Make property specific keyframes when a property appears in some keyframes, but not in the last keyframe.',
-    function() {
-      assert.throws(function() {
-        makePropertySpecificKeyframeGroups(normalize(
-          [
-          {left: '0px', top: '0px'},
-          {left: '10px', top: '10px'},
-          {top: '20px'}
-          ])
-        );
-      });
-    });
+    assert.equal(groups.opacity.length, 4);
+    assert.closeTo(groups.opacity[0].offset, 0, 0.001);
+    assert.equal(groups.opacity[0].value, 1);
+    assert.closeTo(groups.opacity[1].offset, 0.5, 0.001);
+    assert.equal(groups.opacity[1].value, 0);
+    assert.closeTo(groups.opacity[2].offset, 0.75, 0.001);
+    assert.equal(groups.opacity[2].value, 1);
+    assert.closeTo(groups.opacity[3].offset, 1, 0.001);
+    assert.equal(groups.opacity[3].value, 0);
+  });
 
-  test('Make property specific keyframes when a property appears in some keyframes, but not in the first keyframe.',
-    function() {
-      assert.throws(function() {
-        makePropertySpecificKeyframeGroups(normalize(
-          [
-          {left: '0px'},
-          {left: '10px', top: '10px'},
-          {left: '20px', top: '20px'}
-          ])
-        );
-      });
+  test('Make property specific keyframes when the offset of the last keyframe is specified but not equal to 1.', function() {
+    assert.throws(function() {
+      makePropertySpecificKeyframeGroups(normalize([
+        {left: '0px', offset: 0},
+        {left: '20px'},
+        {left: '30px', offset: 0.9}
+      ]));
     });
+  });
 
-  test('Make property specific keyframes where two properties are animated. One property in a keyframe with offset 1. One property in the last keyframe, with no offset.',
-    function() {
-      var groups;
-      assert.doesNotThrow(function() {
-        groups = makePropertySpecificKeyframeGroups(normalize(
-          [
-          {left: '0px', top: '0px', offset: 0},
-          {left: '20px', offset: 1},
-          {top: '20px'}
-          ])
-        );
-      });
-      assert.equal(Object.getOwnPropertyNames(groups).length, 2);
+  test('Make property specific keyframes when no properties are animated, and the offset of the last keyframe is specified but not equal to 1.', function() {
+    var groups;
+    assert.doesNotThrow(function() {
+      groups = makePropertySpecificKeyframeGroups(normalize([
+        {offset: 0},
+        {},
+        {offset: 0.9}
+      ]));
     });
+    assert.equal(Object.getOwnPropertyNames(groups).length, 0);
+  });
 
-  test('Make property specific keyframes where two properties are animated. One property in a keyframe with offset 0. One property in the first keyframe, with no offset.',
-    function() {
-      var groups;
-      assert.doesNotThrow(function() {
-        groups = makePropertySpecificKeyframeGroups(normalize(
-          [
-          {top: '0px'},
-          {left: '0px', offset: 0},
-          {left: '20px', top: '20px', offset: 1}
-          ])
-        );
-      });
-      assert.equal(Object.getOwnPropertyNames(groups).length, 2);
+  test('Make property specific keyframes when a property appears in some keyframes, but not in the last keyframe.', function() {
+    assert.throws(function() {
+      makePropertySpecificKeyframeGroups(normalize([
+        {left: '0px', top: '0px'},
+        {left: '10px', top: '10px'},
+        {top: '20px'}
+      ]));
     });
+  });
+
+  test('Make property specific keyframes when a property appears in some keyframes, but not in the first keyframe.', function() {
+    assert.throws(function() {
+      makePropertySpecificKeyframeGroups(normalize([
+        {left: '0px'},
+        {left: '10px', top: '10px'},
+        {left: '20px', top: '20px'}
+      ]));
+    });
+  });
+
+  test('Make property specific keyframes where two properties are animated. One property in a keyframe with offset 1. One property in the last keyframe, with no offset.', function() {
+    var groups;
+    assert.doesNotThrow(function() {
+      groups = makePropertySpecificKeyframeGroups(normalize([
+        {left: '0px', top: '0px', offset: 0},
+        {left: '20px', offset: 1},
+        {top: '20px'}
+      ]));
+    });
+    assert.equal(Object.getOwnPropertyNames(groups).length, 2);
+  });
+
+  test('Make property specific keyframes where two properties are animated. One property in a keyframe with offset 0. One property in the first keyframe, with no offset.', function() {
+    var groups;
+    assert.doesNotThrow(function() {
+      groups = makePropertySpecificKeyframeGroups(normalize([
+        {top: '0px'},
+        {left: '0px', offset: 0},
+        {left: '20px', top: '20px', offset: 1}
+      ]));
+    });
+    assert.equal(Object.getOwnPropertyNames(groups).length, 2);
+  });
 
   // Test makeInterpolations
-  test('Make interpolations for a simple effect with one property.',
-    function() {
-      var interpolations;
-      assert.doesNotThrow(function() {
-        interpolations = makeInterpolations(makePropertySpecificKeyframeGroups(normalize(
-          [
-          {left: '0px'},
-          {left: '200px', offset: 0.3},
-          {left: '0px'}
-          ])
-        ));
-      });
-      assert.equal(interpolations.length, 2);
-
-      assert.closeTo(interpolations[0].startTime, 0, 0.001);
-      assert.closeTo(interpolations[0].endTime, 0.3, 0.001);
-      assert.equal(interpolations[0].property, 'left');
-      assert.equal(typeof interpolations[0].interpolation, 'function');
-
-      assert.closeTo(interpolations[1].startTime, 0.3, 0.001);
-      assert.closeTo(interpolations[1].endTime, 1, 0.001);
-      assert.equal(interpolations[1].property, 'left');
-      assert.equal(typeof interpolations[1].interpolation, 'function');
+  test('Make interpolations for a simple effect with one property.', function() {
+    var interpolations;
+    assert.doesNotThrow(function() {
+      interpolations = makeInterpolations(makePropertySpecificKeyframeGroups(normalize([
+        {left: '0px'},
+        {left: '200px', offset: 0.3},
+        {left: '0px'}
+      ])));
     });
+    assert.equal(interpolations.length, 2);
+
+    assert.closeTo(interpolations[0].startTime, 0, 0.001);
+    assert.closeTo(interpolations[0].endTime, 0.3, 0.001);
+    assert.equal(interpolations[0].property, 'left');
+    assert.equal(typeof interpolations[0].interpolation, 'function');
+
+    assert.closeTo(interpolations[1].startTime, 0.3, 0.001);
+    assert.closeTo(interpolations[1].endTime, 1, 0.001);
+    assert.equal(interpolations[1].property, 'left');
+    assert.equal(typeof interpolations[1].interpolation, 'function');
+  });
 });
 
 suite('effect-convertEffectInput', function() {
@@ -386,71 +338,62 @@ suite('effect-convertEffectInput', function() {
     this.target.remove();
   });
 
-  test('Convert effect input for a simple effect with one property.',
-    function() {
-      var effectFunction;
-      assert.doesNotThrow(function() {
-        effectFunction = minifill.convertEffectInput(
-          [
-          {left: '0px'},
-          {left: '200px', offset: 0.3},
-          {left: '100px'}
-          ]
-        );
-      });
-
-      var targetLeftAsNumber = (function() {
-        var left = getComputedStyle(this.target).left;
-        return Number(left.substring(0, left.length - 2));
-      }).bind(this);
-
-      effectFunction(this.target, 0);
-      assert.closeTo(targetLeftAsNumber(), 0, 0.001);
-      effectFunction(this.target, 0.075);
-      assert.closeTo(targetLeftAsNumber(), 50, 0.001);
-      effectFunction(this.target, 0.15);
-      assert.closeTo(targetLeftAsNumber(), 100, 0.001);
-      effectFunction(this.target, 0.65);
-      assert.closeTo(targetLeftAsNumber(), 150, 0.001);
-      effectFunction(this.target, 1);
-      assert.closeTo(targetLeftAsNumber(), 100, 0.001);
-      effectFunction(this.target, 2);
-      assert.closeTo(targetLeftAsNumber(), 100, 0.001);
+  test('Convert effect input for a simple effect with one property.', function() {
+    var effectFunction;
+    assert.doesNotThrow(function() {
+      effectFunction = minifill.convertEffectInput([
+        {left: '0px'},
+        {left: '200px', offset: 0.3},
+        {left: '100px'}
+      ]);
     });
 
-  test('Convert effect input where one property is animated and the property has two keyframes at offset 1.',
-    function() {
-      var effectFunction;
-      assert.doesNotThrow(function() {
-        effectFunction = minifill.convertEffectInput(
-          [
-          {left: '0px', offset: 0},
-          {left: '20px', offset: 1},
-          {left: '30px'}
-          ]
-        );
-      });
-      effectFunction(this.target, 1);
-      assert.equal(getComputedStyle(this.target).left, '20px');
-      effectFunction(this.target, 2);
-      assert.equal(getComputedStyle(this.target).left, '20px');
+    var targetLeftAsNumber = (function() {
+      var left = getComputedStyle(this.target).left;
+      return Number(left.substring(0, left.length - 2));
+    }).bind(this);
+
+    effectFunction(this.target, 0);
+    assert.closeTo(targetLeftAsNumber(), 0, 0.001);
+    effectFunction(this.target, 0.075);
+    assert.closeTo(targetLeftAsNumber(), 50, 0.001);
+    effectFunction(this.target, 0.15);
+    assert.closeTo(targetLeftAsNumber(), 100, 0.001);
+    effectFunction(this.target, 0.65);
+    assert.closeTo(targetLeftAsNumber(), 150, 0.001);
+    effectFunction(this.target, 1);
+    assert.closeTo(targetLeftAsNumber(), 100, 0.001);
+    effectFunction(this.target, 2);
+    assert.closeTo(targetLeftAsNumber(), 100, 0.001);
+  });
+
+  test('Convert effect input where one property is animated and the property has two keyframes at offset 1.', function() {
+    var effectFunction;
+    assert.doesNotThrow(function() {
+      effectFunction = minifill.convertEffectInput([
+        {left: '0px', offset: 0},
+        {left: '20px', offset: 1},
+        {left: '30px'}
+      ]);
+    });
+    effectFunction(this.target, 1);
+    assert.equal(getComputedStyle(this.target).left, '20px');
+    effectFunction(this.target, 2);
+    assert.equal(getComputedStyle(this.target).left, '20px');
+  });
+
+  test('Convert effect input and apply effect at fraction null.', function() {
+    var effectFunction;
+    assert.doesNotThrow(function() {
+      effectFunction = minifill.convertEffectInput([
+        {left: '0px'},
+        {left: '100px'}
+      ]);
     });
 
-  test('Convert effect input and apply effect at fraction null.',
-    function() {
-      var effectFunction;
-      assert.doesNotThrow(function() {
-        effectFunction = minifill.convertEffectInput(
-          [
-          {left: '0px'},
-          {left: '100px'}
-          ]
-        );
-      });
-
-      effectFunction(this.target, 1);
-      assert.equal(getComputedStyle(this.target).left, '100px');
-      effectFunction(this.target, null);
-      assert.equal(getComputedStyle(this.target).left, 'auto');
-    });
+    effectFunction(this.target, 1);
+    assert.equal(getComputedStyle(this.target).left, '100px');
+    effectFunction(this.target, null);
+    assert.equal(getComputedStyle(this.target).left, 'auto');
+  });
 });

--- a/test/js/transform-handler.js
+++ b/test/js/transform-handler.js
@@ -1,52 +1,60 @@
 suite('transform-handler parsing', function() {
   test('parse skew values', function() {
-    assert.deepEqual(parseTransform('skew(10deg) skew(12deg,45deg) skewX(0) skewY(1.5rad)'),
-        [['skew', [{deg: 10}, {deg: 0}]],
-        ['skew', [{deg: 12}, {deg: 45}]],
-        ['skewx', [{deg: 0}]],
-        ['skewy', [{rad: 1.5}]]]);
+    assert.deepEqual(parseTransform('skew(10deg) skew(12deg,45deg) skewX(0) skewY(1.5rad)'), [
+      ['skew', [{deg: 10}, {deg: 0}]],
+      ['skew', [{deg: 12}, {deg: 45}]],
+      ['skewx', [{deg: 0}]],
+      ['skewy', [{rad: 1.5}]]
+    ]);
   });
 
   test('parse scale values', function() {
-    assert.deepEqual(parseTransform('scale(-2) scale(3,-4) scaleX(5) scaleY(-1) scaleZ(-3)'),
-        [['scale', [-2, -2]],
-        ['scale', [3, -4]],
-        ['scalex', [5]],
-        ['scaley', [-1]],
-        ['scalez', [-3]]]);
+    assert.deepEqual(parseTransform('scale(-2) scale(3,-4) scaleX(5) scaleY(-1) scaleZ(-3)'), [
+      ['scale', [-2, -2]],
+      ['scale', [3, -4]],
+      ['scalex', [5]],
+      ['scaley', [-1]],
+      ['scalez', [-3]]
+    ]);
     assert.deepEqual(parseTransform('scale3d(-2, 0, 7)'),
         [['scale3d', [-2, 0, 7]]]);
   });
 
   test('parse rotate values', function() {
-    assert.deepEqual(parseTransform('rotate(10deg) rotateX(0) rotateY(1.5rad) rotateZ(50grad)'),
-        [['rotate', [{deg: 10}]],
-        ['rotatex', [{deg: 0}]],
-        ['rotatey', [{rad: 1.5}]],
-        ['rotatez', [{grad: 50}]]]);
+    assert.deepEqual(parseTransform('rotate(10deg) rotateX(0) rotateY(1.5rad) rotateZ(50grad)'), [
+      ['rotate', [{deg: 10}]],
+      ['rotatex', [{deg: 0}]],
+      ['rotatey', [{rad: 1.5}]],
+      ['rotatez', [{grad: 50}]]
+    ]);
   });
 
   test('parse translate values', function() {
-    assert.deepEqual(parseTransform('translate(20%, 30px) translate(30em, 40%) translate(50vw) translate(0)'),
-        [['translate', [{'%': 20}, {px: 30}]],
-        ['translate', [{em: 30}, {'%': 40}]],
-        ['translate', [{vw: 50}, {px: 0}]],
-        ['translate', [{px: 0}, {px: 0}]]]);
-    assert.deepEqual(parseTransform('translateX(10px) translateX(20%) translateX(0)'),
-        [['translatex', [{px: 10}]],
-        ['translatex', [{'%': 20}]],
-        ['translatex', [{px: 0}]]]);
-    assert.deepEqual(parseTransform('translateY(10px) translateY(20%) translateY(0)'),
-        [['translatey', [{px: 10}]],
-        ['translatey', [{'%': 20}]],
-        ['translatey', [{px: 0}]]]);
-    assert.deepEqual(parseTransform('translateZ(10px) translateZ(0)'),
-        [['translatez', [{px: 10}]],
-        ['translatez', [{px: 0}]]]);
-    assert.deepEqual(parseTransform('translate3d(10px, 20px, 30px) translate3d(0, 40%, 0) translate3d(50%, 0, 60px)'),
-        [['translate3d', [{px: 10}, {px: 20}, {px: 30}]],
-        ['translate3d', [{px: 0}, {'%': 40}, {px: 0}]],
-        ['translate3d', [{'%': 50}, {px: 0}, {px: 60}]]]);
+    assert.deepEqual(parseTransform('translate(20%, 30px) translate(30em, 40%) translate(50vw) translate(0)'), [
+      ['translate', [{'%': 20}, {px: 30}]],
+      ['translate', [{em: 30}, {'%': 40}]],
+      ['translate', [{vw: 50}, {px: 0}]],
+      ['translate', [{px: 0}, {px: 0}]]
+    ]);
+    assert.deepEqual(parseTransform('translateX(10px) translateX(20%) translateX(0)'), [
+      ['translatex', [{px: 10}]],
+      ['translatex', [{'%': 20}]],
+      ['translatex', [{px: 0}]]
+    ]);
+    assert.deepEqual(parseTransform('translateY(10px) translateY(20%) translateY(0)'), [
+      ['translatey', [{px: 10}]],
+      ['translatey', [{'%': 20}]],
+      ['translatey', [{px: 0}]]
+    ]);
+    assert.deepEqual(parseTransform('translateZ(10px) translateZ(0)'), [
+      ['translatez', [{px: 10}]],
+      ['translatez', [{px: 0}]]
+    ]);
+    assert.deepEqual(parseTransform('translate3d(10px, 20px, 30px) translate3d(0, 40%, 0) translate3d(50%, 0, 60px)'), [
+      ['translate3d', [{px: 10}, {px: 20}, {px: 30}]],
+      ['translate3d', [{px: 0}, {'%': 40}, {px: 0}]],
+      ['translate3d', [{'%': 50}, {px: 0}, {px: 60}]]
+    ]);
   });
 
   test('invalid transforms fail to parse', function() {


### PR DESCRIPTION
Turns back on strict mode but disables the top-level blank line rules.
