### PR TITLE
Fix forward fill (also get maxifill tests working correctly).

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -88,17 +88,17 @@
     var pendingEffects = [];
     timeline.players = timeline.players.filter(function(player) {
       if (!(player.paused || player.finished)) {
-        ticking = true;
         if (player._startTime === null)
           player.startTime = t - player.__currentTime / player.playbackRate;
         player._currentTime = (t - player.startTime) * player.playbackRate;
-
-        // Execute effect clearing before effect applying.
-        if (!player._inEffect)
-          player._source();
-        else
-          pendingEffects.push(player._source);
+        if (!player.finished)
+          ticking = true;
       }
+      // Execute effect clearing before effect applying.
+      if (!player._inEffect)
+        player._source();
+      else
+        pendingEffects.push(player._source);
 
       player._fireEvents();
 

--- a/target-config.js
+++ b/target-config.js
@@ -51,6 +51,7 @@
     'test/js/player.js',
     'test/js/property-interpolation.js',
     'test/js/transform-handler.js',
+    'test/js/timeline.js'
   ];
 
   // This object specifies the source and test files for different Web Animation build targets.

--- a/test/js/player.js
+++ b/test/js/player.js
@@ -144,6 +144,7 @@ suite('player', function() {
     assert.equal(p.startTime, 500);
     assert.equal(p.finished, true);
     assert.equal(p.playbackRate, 1);
+    setTicking(true);
     p.play();
     assert.equal(p.startTime, 2600);
     assert.equal(p.currentTime, 0);
@@ -160,6 +161,7 @@ suite('player', function() {
     assert.equal(p.currentTime, 0);
     assert.equal(p.finished, true);
     assert.equal(p.playbackRate, -1);
+    setTicking(true);
     p.play();
     assert.equal(p.startTime, 3900);
     assert.equal(p.currentTime, 3000);


### PR DESCRIPTION
(1) We still want to apply the effects of players that are finished, because otherwise they could be cleared by players waiting to start. But...
(2) if we set ticking to true for these players, we'll tick for ever in the presence of forward fill.
