### PR TITLE
Fix missed rename to webAnimationsTargetConfig in target-loader.js

### DIFF
--- a/target-loader.js
+++ b/target-loader.js
@@ -5,7 +5,7 @@
 
   var scripts = document.getElementsByTagName('script');
   var location = scripts[scripts.length - 1].src.replace(/[^\/]+$/, '');
-  targetConfig[target].src.forEach(function(sourceFile) {
+  webAnimationsTargetConfig[target].src.forEach(function(sourceFile) {
     document.write('<script src="' + location + sourceFile + '"></script>');
   });
 })();


### PR DESCRIPTION
Importing web-animations.js was not working, this patch fixes the bug.
