### PR TITLE
check for NaN in calculateTransformedTime

### DIFF
--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -194,6 +194,8 @@
     var currentDirectionIsForwards = timing.direction == 'normal' || timing.direction == (currentIterationIsOdd ? 'alternate-reverse' : 'alternate');
     var directedTime = currentDirectionIsForwards ? iterationTime : iterationDuration - iterationTime;
     var timeFraction = directedTime / iterationDuration;
+    if (isNaN(timeFraction))
+      return null;
     return iterationDuration * timing.easing(timeFraction);
   }
 


### PR DESCRIPTION
Otherwise, the cubic interpolator (possibly others?) will infinite loop because it never satisfies this condition-

```
    if (Math.abs(x - xEst) < 0.001) {
```

where `x` is `NaN`. `NaN - number == NaN`, `NaN < 0.001 == false`.
