### PR TITLE
fix timing test to reset minifill _players

### DIFF
--- a/test/js/timing.js
+++ b/test/js/timing.js
@@ -1,6 +1,6 @@
 suite('timing-tests', function() {
   setup(function() {
-    document.timeline._players = [];
+    webAnimationsMinifill.timeline._players = [];
   });
 
   test('pause and scrub', function() {


### PR DESCRIPTION
Broken after [this](https://github.com/web-animations/web-animations-next/commit/7d102082292c4e893af3066d4dd09926f95996ac), code still assumed it was in maxifill.
