### PR TITLE
Fix consumeParenthesized

### DIFF
--- a/src/handler-utils.js
+++ b/src/handler-utils.js
@@ -68,7 +68,7 @@
       }
     }
     var parsed = parser(string.substr(0, n));
-    return parsed ? [parsed, string.substr(n)] : undefined;
+    return parsed == undefined ? undefined : [parsed, string.substr(n)];
   }
 
   function lcm(a, b) {


### PR DESCRIPTION
Need to explicitly check against undefined, otherwise '0' counts as a failed parse.
