### PR TITLE
Initialize group child players when group player is created.

### DIFF
--- a/src/animation-constructor.js
+++ b/src/animation-constructor.js
@@ -94,7 +94,7 @@
 
   // TODO: Call into this less frequently.
   scope.Player.prototype._updateChildren = function() {
-    if (this.startTime === null || !this.source || !this._isGroup)
+    if (!this.source || !this._isGroup)
       return;
     var offset = this.source._timing.delay;
     for (var i = 0; i < this.source.children.length; i++) {

--- a/src/group-constructors.js
+++ b/src/group-constructors.js
@@ -75,6 +75,7 @@
     player._player._wrapper = player;
     player._isGroup = true;
     scope.awaitStartTime(player);
+    player._updateChildren();
   };
 
 


### PR DESCRIPTION
@shans @dstockwell 
I don't know if this is the best way to achieve this, but it fixes the group play-pause-seek problem and doesn't break any tests.

Previously, playing, pausing and seeking a group would produce a paused group player with correct current time and no children. With this change you get a fully populated group player, and the children have seeked current times too. 
