### PR TITLE
android 4.3 has no performance.now

### DIFF
--- a/src/tick.js
+++ b/src/tick.js
@@ -50,7 +50,8 @@
 
   function InternalTimeline() {
     this._players = [];
-    this.currentTime = window.performance ? performance.now() : 0;
+    // Android 4.3 browser has window.performance, but not window.performance.now
+    this.currentTime = window.performance && performance.now ? performance.now() : 0;
   };
 
   InternalTimeline.prototype = {


### PR DESCRIPTION
I know that android 4.3 isn't supported, but this easy fix actually makes web-animations-next somewhat work on 4.3. (when provided with an additional `requestAnimationFrame` polyfill). 
