### PR TITLE
Don't update children of cancelled group

### DIFF
--- a/src/animation-constructor.js
+++ b/src/animation-constructor.js
@@ -98,7 +98,7 @@
 
   // TODO: Call into this less frequently.
   scope.Player.prototype._updateChildren = function() {
-    if (this.paused || !this.source || !this._isGroup)
+    if (this.paused || !this.source || !this._isGroup || this.playState == 'idle')
       return;
     var offset = this.source._timing.delay;
     for (var i = 0; i < this.source.children.length; i++) {

--- a/test/js/group-player.js
+++ b/test/js/group-player.js
@@ -332,6 +332,17 @@ suite('group-player', function() {
     assert.equal(getComputedStyle(this.complexTarget).marginLeft, '0px');
   });
 
+  test('cancelling group players before tick', function() {
+    tick(0);
+    var player = document.timeline.play(this.complexSource);
+    player.cancel();
+    assert.equal(player.currentTime, null);
+    assert.equal(getComputedStyle(this.complexTarget).marginLeft, '0px');
+    tick(4);
+    assert.equal(player.currentTime, null);
+    assert.equal(getComputedStyle(this.complexTarget).marginLeft, '0px');
+  });
+
   test('redundant animation node wrapping', function() {
     tick(100);
     var animation = new AnimationSequence([


### PR DESCRIPTION
Don't update a group's children if the group is cancelled (idle play state). This fixed a bug where if you play a group and immediately cancel it, the group continues to play.