### PR TITLE
Only clear pending effects once they have been applied

### DIFF
--- a/src/effect-callback.js
+++ b/src/effect-callback.js
@@ -62,7 +62,7 @@
     updating.sort(function(left, right) {
       return left._sequenceNumber - right._sequenceNumber;
     });
-    updating.filter(function(callback) {
+    updating = updating.filter(function(callback) {
       callback();
       if (!callback._player || callback._player.finished || callback._player.paused)
         callback._registered = false;

--- a/src/tick.js
+++ b/src/tick.js
@@ -87,6 +87,7 @@
   var pendingEffects = [];
   function applyPendingEffects() {
     pendingEffects.forEach(function(f) { f(); });
+    pendingEffects.length = 0;
   }
 
   var originalGetComputedStyle = window.getComputedStyle;
@@ -125,7 +126,6 @@
       return player._inTimeline;
     });
 
-    pendingEffects.length = 0;
     pendingEffects.push.apply(pendingEffects, newPendingClears);
     pendingEffects.push.apply(pendingEffects, newPendingEffects);
 

--- a/src/tick.js
+++ b/src/tick.js
@@ -126,6 +126,7 @@
       return player._inTimeline;
     });
 
+    // FIXME: Should remove dupliactes from pendingEffects.
     pendingEffects.push.apply(pendingEffects, newPendingClears);
     pendingEffects.push.apply(pendingEffects, newPendingEffects);
 

--- a/test/js/group-player.js
+++ b/test/js/group-player.js
@@ -1024,9 +1024,9 @@ suite('group-player', function() {
 
   test('fill none groups with fill none children do not fill', function() {
     var anim = new Animation(
-        this.target,
-        [{marginLeft: '0px'}, {marginLeft: '100px'}],
-        {duration: 500, fill: 'none'});
+      this.target,
+      [{marginLeft: '0px'}, {marginLeft: '100px'}],
+      {duration: 500, fill: 'none'});
     var group = new AnimationGroup([anim], {fill: 'none'});
     var player = document.timeline.play(group);
 
@@ -1036,5 +1036,7 @@ suite('group-player', function() {
     assert.equal(getComputedStyle(this.target).marginLeft, '50px');
     tick(501);
     assert.equal(getComputedStyle(this.target).marginLeft, '0px');
+    if (this.target.parent)
+          this.target.parent.removeChild(target);
   });
 });

--- a/test/js/group-player.js
+++ b/test/js/group-player.js
@@ -1024,9 +1024,9 @@ suite('group-player', function() {
 
   test('fill none groups with fill none children do not fill', function() {
     var anim = new Animation(
-      this.target,
-      [{marginLeft: '0px'}, {marginLeft: '100px'}],
-      {duration: 500, fill: 'none'});
+        this.target,
+        [{marginLeft: '0px'}, {marginLeft: '100px'}],
+        {duration: 500, fill: 'none'});
     var group = new AnimationGroup([anim], {fill: 'none'});
     var player = document.timeline.play(group);
 

--- a/test/js/group-player.js
+++ b/test/js/group-player.js
@@ -1036,7 +1036,5 @@ suite('group-player', function() {
     assert.equal(getComputedStyle(this.target).marginLeft, '50px');
     tick(501);
     assert.equal(getComputedStyle(this.target).marginLeft, '0px');
-    if (this.target.parent)
-      this.target.parent.removeChild(target);
   });
 });

--- a/test/js/group-player.js
+++ b/test/js/group-player.js
@@ -1021,4 +1021,20 @@ suite('group-player', function() {
     assert.equal(player._childPlayers[0]._player.playbackRate, -1);
 
   });
+
+  test('fill none groups with fill none children do not fill', function() {
+    var anim = new Animation(
+      this.target,
+      [{marginLeft: '0px'}, {marginLeft: '100px'}],
+      {duration: 500, fill: 'none'});
+    var group = new AnimationGroup([anim], {fill: 'none'});
+    var player = document.timeline.play(group);
+
+    tick(0);
+    assert.equal(getComputedStyle(this.target).marginLeft, '0px');
+    tick(250);
+    assert.equal(getComputedStyle(this.target).marginLeft, '50px');
+    tick(501);
+    assert.equal(getComputedStyle(this.target).marginLeft, '0px');
+  });
 });

--- a/test/js/group-player.js
+++ b/test/js/group-player.js
@@ -1024,9 +1024,9 @@ suite('group-player', function() {
 
   test('fill none groups with fill none children do not fill', function() {
     var anim = new Animation(
-      this.target,
-      [{marginLeft: '0px'}, {marginLeft: '100px'}],
-      {duration: 500, fill: 'none'});
+        this.target,
+        [{marginLeft: '0px'}, {marginLeft: '100px'}],
+        {duration: 500, fill: 'none'});
     var group = new AnimationGroup([anim], {fill: 'none'});
     var player = document.timeline.play(group);
 
@@ -1037,6 +1037,6 @@ suite('group-player', function() {
     tick(501);
     assert.equal(getComputedStyle(this.target).marginLeft, '0px');
     if (this.target.parent)
-          this.target.parent.removeChild(target);
+      this.target.parent.removeChild(target);
   });
 });

--- a/test/js/group-player.js
+++ b/test/js/group-player.js
@@ -1036,5 +1036,6 @@ suite('group-player', function() {
     assert.equal(getComputedStyle(this.target).marginLeft, '50px');
     tick(501);
     assert.equal(getComputedStyle(this.target).marginLeft, '0px');
+    tick(502);
   });
 });

--- a/test/js/tick.js
+++ b/test/js/tick.js
@@ -10,7 +10,6 @@ suite('tick-tests', function() {
     assert.equal(isTicking(), true);
     tick(1100);
     assert.equal(player.finished, true);
-    console.log(webAnimations1.timeline._players.length);
     assert.equal(webAnimations1.timeline._players.length, 1);
     assert.equal(isTicking(), false);
   });

--- a/test/js/tick.js
+++ b/test/js/tick.js
@@ -10,6 +10,7 @@ suite('tick-tests', function() {
     assert.equal(isTicking(), true);
     tick(1100);
     assert.equal(player.finished, true);
+    console.log(webAnimations1.timeline._players.length);
     assert.equal(webAnimations1.timeline._players.length, 1);
     assert.equal(isTicking(), false);
   });


### PR DESCRIPTION
This fixes a bug where a group who has fill none, and whose children also have fill none, doesn't cancel its effects when it finishes.