### PR TITLE
Fix condition testing when effect callbacks are still ticking

### DIFF
--- a/src/effect-callback.js
+++ b/src/effect-callback.js
@@ -64,7 +64,8 @@
     });
     updating = updating.filter(function(callback) {
       callback();
-      if (!callback._player || callback._player.finished || callback._player.paused)
+      var playState = callback._player ? callback._player.playState : 'idle';
+      if (playState != 'running' && playState != 'pending')
         callback._registered = false;
       return callback._registered;
     });


### PR DESCRIPTION
`player.finished` and `player.paused` no longer exist.

Manually verified that the `tick()` function in `effect-callback.js` is no longer called after the effect callback has finished.