### PR TITLE
Work around broken fill-forwards cancel in M40

### DIFF
--- a/src/web-animations-next-player.js
+++ b/src/web-animations-next-player.js
@@ -172,7 +172,7 @@
       // https://github.com/web-animations/web-animations-next/issues/278.
       // Remove when Chrome 41 goes stable.
       var currentTime = this.currentTime;
-      this.currentTime = 0;
+      this.currentTime = this.source.activeDuration ? this.source.activeDuration / 2 : 1;
       this._player.cancel();
       this.currentTime = currentTime;
       this._register();

--- a/src/web-animations-next-player.js
+++ b/src/web-animations-next-player.js
@@ -168,7 +168,13 @@
       // TODO: child players??
     },
     cancel: function() {
+      // FIXME: These currentTime manipulations are a workaround for
+      // https://github.com/web-animations/web-animations-next/issues/278.
+      // Remove when Chrome 41 goes stable.
+      var currentTime = this.currentTime;
+      this.currentTime = 0;
       this._player.cancel();
+      this.currentTime = currentTime;
       this._register();
       this._removePlayers();
     },


### PR DESCRIPTION
This works around https://github.com/web-animations/web-animations-next/issues/278 which causes https://github.com/Polymer/paper-dropdown-menu/issues/45.

@morethanreal, @dstockwell, @mikelawther 