### PR TITLE
Intial custom effect "last" time fraction should be null, not undef.

### DIFF
--- a/src/effect-callback.js
+++ b/src/effect-callback.js
@@ -20,7 +20,7 @@
     var target = player.source.target;
     var effect = player.source.effect;
     var timing = player.source.timing;
-    var last = undefined;
+    var last = null;
     timing = shared.normalizeTimingInput(timing);
     var callback = function() {
       var t = callback._player ? callback._player.currentTime : null;

--- a/test/js/effect-callback.js
+++ b/test/js/effect-callback.js
@@ -12,7 +12,7 @@ suite('effect-callback', function() {
     tick(200);
     tick(1000);
     tick(1100);
-    assert.deepEqual(fractions, [null, 0, 0.1]);
+    assert.deepEqual(fractions, [0, 0.1]);
   });
 
   test('duration 0 players get sampled at least once', function() {


### PR DESCRIPTION
Fixes a bug where custom effects in a sequence were sampling on the first tick of the sequence because null != undefined.