### PR TITLE
Return early for special cubic params

### DIFF
--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -66,6 +66,9 @@
       return linear;
     }
     return function(x) {
+      if (x == 0 || x == 1) {
+        return x;
+      }
       var start = 0, end = 1;
       while (1) {
         var mid = (start + end) / 2;

--- a/test/js/timing-utilities.js
+++ b/test/js/timing-utilities.js
@@ -16,14 +16,20 @@ suite('timing-utilities', function() {
     }
     assert.closeTo(f(0.1844), 0.2601, 0.01);
     assert.closeTo(g(0.1844), 0.2601, 0.01);
+    assert.equal(f(0), 0);
+    assert.equal(f(1), 1);
+    assert.equal(g(0), 0);
+    assert.equal(g(1), 1);
 
     f = toTimingFunction('cubic-bezier(0, 1, 1, 0)');
     assert.closeTo(f(0.104), 0.392, 0.01);
 
     function isLinear(f) {
+      assert.equal(f(0), 0);
       assert.equal(f(0.1), 0.1);
       assert.equal(f(0.4), 0.4);
       assert.equal(f(0.9), 0.9);
+      assert.equal(f(1), 1);
     }
 
     f = toTimingFunction('cubic-bezier(0, 1, -1, 1)');


### PR DESCRIPTION
When 0 or 1 is passed, cubic timing function should return 0 or 1 respectively.

Fixes #311