### PR TITLE
Fix groups with infinite iteration children

### DIFF
--- a/src/web-animations-next-animation.js
+++ b/src/web-animations-next-animation.js
@@ -85,9 +85,18 @@
       }.bind(this));
     },
     _arrangeChildren: function(childAnimation, offset) {
+      console.log('parent start time:', this.startTime,
+        'child start time:', childAnimation.startTime,
+        'child current time:', childAnimation.currentTime,
+        'offset:', offset);
       if (this.startTime === null) {
+        console.log('this.currentTime - offset / this.playbackRate:', this.currentTime - offset / this.playbackRate);
         childAnimation.currentTime = this.currentTime - offset / this.playbackRate;
         childAnimation._startTime = null;
+        console.log('parent start time:', this.startTime,
+        'child start time:', childAnimation.startTime,
+        'child current time:', childAnimation.currentTime,
+        'offset:', offset);
       } else if (childAnimation.startTime !== this.startTime + offset / this.playbackRate) {
         childAnimation.startTime = this.startTime + offset / this.playbackRate;
       }
@@ -117,7 +126,8 @@
       return this._animation.currentTime;
     },
     set currentTime(v) {
-      this._animation.currentTime = v;
+      console.log('set current time: ', v);
+      this._animation.currentTime = isFinite(v) ? v : Math.sign(v) * Number.MAX_VALUE;
       this._register();
       this._forEachChild(function(child, offset) {
         child.currentTime = v - offset;
@@ -127,7 +137,7 @@
       return this._animation.startTime;
     },
     set startTime(v) {
-      this._animation.startTime = v;
+      this._animation.startTime = isFinite(v) ? v : Math.sign(v) * Number.MAX_VALUE;
       this._register();
       this._forEachChild(function(child, offset) {
         child.startTime = v + offset;

--- a/src/web-animations-next-animation.js
+++ b/src/web-animations-next-animation.js
@@ -85,18 +85,9 @@
       }.bind(this));
     },
     _arrangeChildren: function(childAnimation, offset) {
-      console.log('parent start time:', this.startTime,
-        'child start time:', childAnimation.startTime,
-        'child current time:', childAnimation.currentTime,
-        'offset:', offset);
       if (this.startTime === null) {
-        console.log('this.currentTime - offset / this.playbackRate:', this.currentTime - offset / this.playbackRate);
         childAnimation.currentTime = this.currentTime - offset / this.playbackRate;
         childAnimation._startTime = null;
-        console.log('parent start time:', this.startTime,
-        'child start time:', childAnimation.startTime,
-        'child current time:', childAnimation.currentTime,
-        'offset:', offset);
       } else if (childAnimation.startTime !== this.startTime + offset / this.playbackRate) {
         childAnimation.startTime = this.startTime + offset / this.playbackRate;
       }
@@ -126,7 +117,6 @@
       return this._animation.currentTime;
     },
     set currentTime(v) {
-      console.log('set current time: ', v);
       this._animation.currentTime = isFinite(v) ? v : Math.sign(v) * Number.MAX_VALUE;
       this._register();
       this._forEachChild(function(child, offset) {

--- a/test/js/group-animation.js
+++ b/test/js/group-animation.js
@@ -708,6 +708,26 @@ suite('group-animation', function() {
     );
   });
 
+  test('Sequences child timing is correct work when a child has infinite iterations.', function() {
+    var seqBothBothFirst = this.makeInfiniteChildSeq('both', 'both', 'first');
+    var animation = document.timeline.play(seqBothBothFirst);
+    tick(0);
+    assert.equal(animation.currentTime, 0);
+    assert.equal(animation.startTime, 0);
+    assert.equal(animation._childAnimations[0].currentTime, 0);
+    assert.equal(animation._childAnimations[0].startTime, 0);
+    assert.equal(animation._childAnimations[1].currentTime, -Number.MAX_VALUE);
+    assert.equal(animation._childAnimations[1].startTime, Number.MAX_VALUE);
+
+    tick(500);
+    assert.equal(animation.currentTime, 500);
+    assert.equal(animation.startTime, 0);
+    assert.equal(animation._childAnimations[0].currentTime, 500);
+    assert.equal(animation._childAnimations[0].startTime, 0);
+    assert.equal(animation._childAnimations[1].currentTime, -Number.MAX_VALUE);
+    assert.equal(animation._childAnimations[1].startTime, Number.MAX_VALUE);
+  });
+
   test('Sequences work when the first child has infinite iterations. Sequence has fill both, children fill backwards.', function() {
     var seqBothBackwardsFirst = this.makeInfiniteChildSeq('both', 'backwards', 'first');
     this.checkInfiniteSeqChildBehavior(seqBothBackwardsFirst,


### PR DESCRIPTION
Make groups with infinite iteration children work for native-backed polyfill.

Add tests for groups with infinite iteration children.

NB: Tests don't test the bug that this patch fixes, as it only shows with native Animations. However this case used to be a lot worse, so it seems worthwhile having tests.

@dstockwell @shans 