### PR TITLE
Provide uncompressed versions of files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,8 @@ node_modules
 !node_modules/mocha/LICENCE
 !node_modules/chai/chai.js
 !node_modules/chai-LICENCE
-web-animations-*.min.js
-web-animations-*.min.js.map
-web-animations.min.js
-web-animations.min.js.map
+web-animations*.js
+web-animations*.js.map
 inter-*
 *~
 sauce_connect.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,9 +40,29 @@ module.exports = function(grunt) {
         wrap: false,
         compress: {
           global_defs: defines,
-          dead_code: false
+          sequences: false,
+          properties: false,
+          dead_code: false,
+          conditionals: false,
+          comparisons: false,
+          evaluate: false,
+          booleans: false,
+          loops: false,
+          unused: false,
+          hoist_funs: false,
+          hoist_vars: false,
+          if_return: false,
+          join_vars: false,
+          cascade: false,
+          negate_iife: false,
+          side_effects: false
         },
-        mangle: false
+        mangle: false,
+        beautify: {
+          beautify: true,
+          indent_level: 2,
+          bracketize: true
+        }
       },
       nonull: true,
       dest: target,
@@ -120,8 +140,8 @@ module.exports = function(grunt) {
     var config = targetConfig[target];
     return genTarget(target).concat([
       concat(config.scopeSrc.concat(config.sharedSrc).concat(config.webAnimations1Src), 'inter-raw-' + target + '.js', concatDefines),
-      guard('inter-raw-' + target + '.js', 'inter-' + target + '.js'),
-      compress('inter-' + target + '.js', target + '.min.js', concatDefines)
+      guard('inter-raw-' + target + '.js', target + '.js'),
+      compress(target + '.js', target + '.min.js', concatDefines)
     ]);
   }
 
@@ -133,8 +153,8 @@ module.exports = function(grunt) {
       guard('inter-component-' + target + 'web-animations-1.js', 'inter-guarded-' + target + '-web-animations-1.js'),
       concat(config.webAnimationsNextSrc, 'inter-component-' + target + '.js', concatDefines),
       concatWithMaps(['inter-' + target + '-preamble.js', 'inter-guarded-' + target + '-web-animations-1.js', 'inter-component-' + target + '.js'],
-          'inter-' + target + '.js'),
-      compress('inter-' + target + '.js', target + '.min.js', concatDefines)
+          target + '.js'),
+      compress(target + '.js', target + '.min.js', concatDefines)
     ]);
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "karma-sauce-launcher": "~0.2.3",
     "grunt-checkrepo": "~0.1.0",
     "grunt-saucelabs": "~4.0.2",
-    "grunt-checkrepo": "~0.1.0",
     "grunt-git-status": "~1.0.0",
     "grunt-template": "~0.2.3",
     "source-map": "~0.1.40"


### PR DESCRIPTION
As per https://github.com/web-animations/web-animations-js/issues/19, `*.dev.js` files are non-consumable with es 2015 module syntax.

This PR makes grunt to produce uncompressed versions of files.

Feel free to close this if you are not interested in providing these files.

P.S. `grunt clean` also removes committed files. Not sure if that's intended.
