### PR TITLE
Only arrange children in root animation

### DIFF
--- a/src/web-animations-next-animation.js
+++ b/src/web-animations-next-animation.js
@@ -132,7 +132,7 @@
     _constructChildAnimations: function() {
       if (!this.effect || !this._isGroup)
         return;
-      var offset = this.effect._timing.delay;
+
       this._removeChildAnimations();
       this.effect.children.forEach(function(child) {
         var childAnimation = window.document.timeline._play(child);
@@ -141,12 +141,11 @@
         if (this._paused)
           childAnimation.pause();
         child._animation = this.effect._animation;
-
-        this._arrangeChildren(childAnimation, offset);
-
-        if (this.effect instanceof window.SequenceEffect)
-          offset += scope.groupChildDuration(child);
       }.bind(this));
+
+      if (!this.effect._parent) {
+        this._updateChildren();
+      }
     },
     _arrangeChildren: function(childAnimation, offset) {
       if (this.startTime === null) {


### PR DESCRIPTION
since setting the currentTime/startTime of a child animation is already recursive.
