### PR TITLE
Workaround for window.performance not being available on mobile safari

### DIFF
--- a/src/tick.js
+++ b/src/tick.js
@@ -77,7 +77,7 @@
   } else {
     var now = function() {
       if (_now == undefined)
-        _now = performance.now();
+        _now = window.performance && performance.now ? performance.now() : Date.now();
       return _now;
     };
   }


### PR DESCRIPTION
This comes from this issue - https://github.com/web-animations/web-animations-js/issues/35
Thanks & sorry for the delay!