### PR TITLE
Update package.json for NPM 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,22 @@
 {
   "name": "web-animations-js",
-  "private": true,
+  "description": "JavaScript implementation of the Web Animations API",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-animations/web-animations-js.git"
   },
+  "version": "2.1.3",
+  "keywords": [
+    "animations",
+    "polyfill"
+  ],
+  "homepage": "https://github.com/web-animations",
+  "license": "Apache2",
+  "main": "web-animations.min.js",
+  "files": [
+    "*.min.js",
+    "*.min.js.map"
+  ],
   "devDependencies": {
     "mocha": "1.21.4",
     "chai": "^1.9.1",


### PR DESCRIPTION
This makes Web Animations public on NPM (Node Package Manager), and defines a specific version (this is, unfortunately, required for NPM, and will need to be updated on every release).

Alternative approach: we could leave `version` out (since `web-animations-next` has no notion of versions), and set it only as part of the merge to `web-animations-js`.