### PR TITLE
Fix teardown in js tests.

### DIFF
--- a/test/js/animation-finish-event.js
+++ b/test/js/animation-finish-event.js
@@ -5,8 +5,7 @@ suite('animation-finish-event', function() {
     this.animation = this.element.animate([], 1000);
   });
   teardown(function() {
-    if (this.element.parent)
-      this.element.removeChild(this.target);
+    this.element.remove();
   });
 
   test('fire when animation completes', function(done) {

--- a/test/js/group-animation-finish-event.js
+++ b/test/js/group-animation-finish-event.js
@@ -13,8 +13,7 @@ suite('group-animation-finish-event', function() {
     this.animation = document.timeline.play(sequenceEffect, 1000);
   });
   teardown(function() {
-    if (this.element.parent)
-      this.element.removeChild(this.element);
+    this.element.remove();
   });
 
   test('fire when animation completes', function(done) {

--- a/test/js/keyframes.js
+++ b/test/js/keyframes.js
@@ -437,8 +437,7 @@ suite('keyframe-interpolations - convertEffectInput', function() {
     document.documentElement.appendChild(this.target);
   });
   teardown(function() {
-    if (this.target.parent)
-      this.target.removeChild(this.target);
+    this.target.remove();
   });
 
   test('Convert effect input for a simple keyframe list with one property.', function() {


### PR DESCRIPTION
Some of the test/js/* test suites have inconsistent teardown()
function definitions that look partially like copy-paste errors. This
patch rewrites those teardowns to make more sense.