### PR TITLE
Typo fix: Replace onfinish with _onfinish

### DIFF
--- a/src/web-animations-next-animation.js
+++ b/src/web-animations-next-animation.js
@@ -221,7 +221,7 @@
         }).bind(this);
       } else {
         this._animation.onfinish = v;
-        this.onfinish = this._animation.onfinish;
+        this._onfinish = this._animation.onfinish;
       }
     },
     get currentTime() {

--- a/test/js/animation-finish-event.js
+++ b/test/js/animation-finish-event.js
@@ -75,4 +75,18 @@ suite('animation-finish-event', function() {
     this.animation.cancel();
     tick(1000);
   });
+
+  test('can wipe onfinish handler by setting it to null', function(done) {
+    var finishAnimation = this.element.animate([], 1100);
+    finishAnimation.onfinish = function(event) {
+      done();
+    };
+
+    this.animation.onfinish = function(event) {
+      assert(false, 'onfinish should be wiped');
+    };
+    this.animation.onfinish = null;
+    tick(0);
+    tick(1200);
+  });
 });


### PR DESCRIPTION
The definition of onfinish in web-animations-next-animation.js refers
to this.onfinish, where it should be this._onfinish.