### PR TITLE
Make invalid easings in animation timing inputs throw a TypeError

### DIFF
--- a/src/keyframe-interpolations.js
+++ b/src/keyframe-interpolations.js
@@ -73,12 +73,13 @@
   function makeInterpolations(propertySpecificKeyframeGroups) {
     var interpolations = [];
     for (var groupName in propertySpecificKeyframeGroups) {
-      var group = propertySpecificKeyframeGroups[groupName];
-      for (var i = 0; i < group.length - 1; i++) {
-        var startTime = group[i].offset;
-        var endTime = group[i + 1].offset;
-        var startValue = group[i].value;
-        var endValue = group[i + 1].value;
+      var keyframes = propertySpecificKeyframeGroups[groupName];
+      for (var i = 0; i < keyframes.length - 1; i++) {
+        var startTime = keyframes[i].offset;
+        var endTime = keyframes[i + 1].offset;
+        var startValue = keyframes[i].value;
+        var endValue = keyframes[i + 1].value;
+        var easing = keyframes[i].easing;
         if (startTime == endTime) {
           if (endTime == 1) {
             startValue = endValue;
@@ -89,7 +90,7 @@
         interpolations.push({
           startTime: startTime,
           endTime: endTime,
-          easing: group[i].easing,
+          easing: shared.toTimingFunction(easing ? easing : 'linear'),
           property: groupName,
           interpolation: scope.propertyInterpolation(groupName, startValue, endValue)
         });

--- a/src/normalize-keyframes.js
+++ b/src/normalize-keyframes.js
@@ -239,8 +239,6 @@
             name: 'NotSupportedError',
             message: 'add compositing is not supported'
           };
-        } else if (member == 'easing') {
-          memberValue = shared.toTimingFunction(memberValue);
         } else {
           memberValue = '' + memberValue;
         }
@@ -248,8 +246,6 @@
       }
       if (keyframe.offset == undefined)
         keyframe.offset = null;
-      if (keyframe.easing == undefined)
-        keyframe.easing = shared.toTimingFunction('linear');
       return keyframe;
     });
 

--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -151,7 +151,7 @@
   function normalizeTimingInput(timingInput, forGroup) {
     timingInput = shared.numericTimingToObject(timingInput);
     var timing = makeTiming(timingInput, forGroup);
-    timing._easing = toTimingFunction(timing.easing);
+    timing._easingFunction = toTimingFunction(timing.easing);
     return timing;
   }
 
@@ -304,7 +304,7 @@
     var currentDirectionIsForwards = timing.direction == 'normal' || timing.direction == (currentIterationIsOdd ? 'alternate-reverse' : 'alternate');
     var directedTime = currentDirectionIsForwards ? iterationTime : iterationDuration - iterationTime;
     var timeFraction = directedTime / iterationDuration;
-    return iterationDuration * timing.easing(timeFraction);
+    return iterationDuration * timing._easingFunction(timeFraction);
   }
 
   function calculateTimeFraction(activeDuration, localTime, timing) {

--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -217,17 +217,21 @@
     }
     styleForCleaning.animationTimingFunction = '';
     styleForCleaning.animationTimingFunction = easing;
-    easing = styleForCleaning.animationTimingFunction;
+    var validatedEasing = styleForCleaning.animationTimingFunction;
 
-    var cubicData = cubicBezierRe.exec(easing);
+    if (validatedEasing == '') {
+      throw new TypeError(easing + ' is not a valid value for easing');
+    }
+
+    var cubicData = cubicBezierRe.exec(validatedEasing);
     if (cubicData) {
       return cubic.apply(this, cubicData.slice(1).map(Number));
     }
-    var stepData = stepRe.exec(easing);
+    var stepData = stepRe.exec(validatedEasing);
     if (stepData) {
       return step(Number(stepData[1]), {'start': Start, 'middle': Middle, 'end': End}[stepData[2]]);
     }
-    var preset = presets[easing];
+    var preset = presets[validatedEasing];
     if (preset) {
       return preset;
     }

--- a/test.html
+++ b/test.html
@@ -1,0 +1,14 @@
+<script src="web-animations-next-lite.dev.js"></script>
+<style>
+#target {
+  position: absolute;
+  top: 0;
+  background: blue;
+  width: 100px;
+  height: 100px;
+}
+</style>
+<div id="target"></div>
+<script>
+var animation = document.timeline.play(new KeyframeEffect(target, [{top: '0px'}, {top: '100px', easing: 'linear'}], 1000));
+</script>

--- a/test/js/keyframes.js
+++ b/test/js/keyframes.js
@@ -444,14 +444,12 @@ suite('keyframes', function() {
 
   test('Make interpolations with invalid easing.', function() {
     var interpolations;
-    assert.doesNotThrow(function() {
+    assert.throws(function() {
       interpolations = makeInterpolations(makePropertySpecificKeyframeGroups(normalizeKeyframes([
         {left: '0px', easing: 'pants and ducks'},
         {left: '200px'},
       ])));
     });
-    assert.equal(interpolations.length, 1);
-    assert.equal(interpolations[0].easing.toString(), 'function (x) { return x; }');
   });
 });
 

--- a/test/js/keyframes.js
+++ b/test/js/keyframes.js
@@ -442,10 +442,9 @@ suite('keyframes', function() {
     assert.equal(typeof interpolations[1].interpolation, 'function');
   });
 
-  test('Make interpolations with invalid easing.', function() {
-    var interpolations;
+  test('Make interpolations with invalid easing should throw.', function() {
     assert.throws(function() {
-      interpolations = makeInterpolations(makePropertySpecificKeyframeGroups(normalizeKeyframes([
+      makeInterpolations(makePropertySpecificKeyframeGroups(normalizeKeyframes([
         {left: '0px', easing: 'pants and ducks'},
         {left: '200px'},
       ])));

--- a/test/js/keyframes.js
+++ b/test/js/keyframes.js
@@ -158,7 +158,7 @@ suite('keyframes', function() {
         {left: '0px'}
       ]);
     });
-    assert.equal('' + normalizedKeyframes[0].easing, 'function (x) { return x; }');
+    assert.equal(normalizedKeyframes[0].easing, 'easy-peasy');
   });
 
   test('Normalize keyframes where some properties are given non-string, non-number values.', function() {
@@ -440,6 +440,18 @@ suite('keyframes', function() {
     assert.closeTo(interpolations[1].endTime, 1, 0.001);
     assert.equal(interpolations[1].property, 'left');
     assert.equal(typeof interpolations[1].interpolation, 'function');
+  });
+
+  test('Make interpolations with invalid easing.', function() {
+    var interpolations;
+    assert.doesNotThrow(function() {
+      interpolations = makeInterpolations(makePropertySpecificKeyframeGroups(normalizeKeyframes([
+        {left: '0px', easing: 'pants and ducks'},
+        {left: '200px'},
+      ])));
+    });
+    assert.equal(interpolations.length, 1);
+    assert.equal(interpolations[0].easing.toString(), 'function (x) { return x; }');
   });
 });
 

--- a/test/js/timing-utilities.js
+++ b/test/js/timing-utilities.js
@@ -33,18 +33,17 @@ suite('timing-utilities', function() {
     f = toTimingFunction('cubic-bezier(0, 1, 1, 0)');
     assert.closeTo(f(0.104), 0.392, 0.01);
 
-    function assertIsLinear(easing) {
-      var f = toTimingFunction(easing);
-      for (var i = 0; i <= 1; i += 0.1) {
-        assert.equal(f(i), i, easing + ' is linear');
-      }
+    function assertThrows(easing) {
+      assert.throws(function() {
+        toTimingFunction(easing);
+      }, easing);
     }
 
-    assertIsLinear('cubic-bezier(.25, 0.1, 0.25, 1.)');
-    assertIsLinear('cubic-bezier(0, 1, -1, 1)');
-    assertIsLinear('an elephant');
-    assertIsLinear('cubic-bezier(-1, 1, 1, 1)');
-    assertIsLinear('cubic-bezier(1, 1, 1)');
+    assertThrows('cubic-bezier(.25, 0.1, 0.25, 1.)');
+    assertThrows('cubic-bezier(0, 1, -1, 1)');
+    assertThrows('an elephant');
+    assertThrows('cubic-bezier(-1, 1, 1, 1)');
+    assertThrows('cubic-bezier(1, 1, 1)');
 
     f = toTimingFunction('steps(10, end)');
     assert.equal(f(0), 0);

--- a/test/js/timing-utilities.js
+++ b/test/js/timing-utilities.js
@@ -1,7 +1,7 @@
 suite('timing-utilities', function() {
   test('normalize timing input', function() {
     assert.equal(normalizeTimingInput(1).duration, 1);
-    assert.equal(normalizeTimingInput(1).easing(0.2), 0.2);
+    assert.equal(normalizeTimingInput(1)._easingFunction(0.2), 0.2);
     assert.equal(normalizeTimingInput(undefined).duration, 0);
   });
   test('calculating active duration', function() {
@@ -90,13 +90,13 @@ suite('timing-utilities', function() {
   });
   test('calculating transformed time', function() {
     // calculateTransformedTime(currentIteration, iterationDuration, iterationTime, timingInput);
-    assert.equal(calculateTransformedTime(4, 1000, 200, {easing: function(x) { return x; }, direction: 'normal'}), 200);
-    assert.equal(calculateTransformedTime(4, 1000, 200, {easing: function(x) { return x; }, direction: 'reverse'}), 800);
-    assert.closeTo(calculateTransformedTime(4, 1000, 200, {easing: function(x) { return x * x; }, direction: 'reverse'}), 640, 0.0001);
-    assert.closeTo(calculateTransformedTime(4, 1000, 600, {easing: function(x) { return x * x; }, direction: 'alternate'}), 360, 0.0001);
-    assert.closeTo(calculateTransformedTime(3, 1000, 600, {easing: function(x) { return x * x; }, direction: 'alternate'}), 160, 0.0001);
-    assert.closeTo(calculateTransformedTime(4, 1000, 600, {easing: function(x) { return x * x; }, direction: 'alternate-reverse'}), 160, 0.0001);
-    assert.closeTo(calculateTransformedTime(3, 1000, 600, {easing: function(x) { return x * x; }, direction: 'alternate-reverse'}), 360, 0.0001);
+    assert.equal(calculateTransformedTime(4, 1000, 200, {_easingFunction: function(x) { return x; }, direction: 'normal'}), 200);
+    assert.equal(calculateTransformedTime(4, 1000, 200, {_easingFunction: function(x) { return x; }, direction: 'reverse'}), 800);
+    assert.closeTo(calculateTransformedTime(4, 1000, 200, {_easingFunction: function(x) { return x * x; }, direction: 'reverse'}), 640, 0.0001);
+    assert.closeTo(calculateTransformedTime(4, 1000, 600, {_easingFunction: function(x) { return x * x; }, direction: 'alternate'}), 360, 0.0001);
+    assert.closeTo(calculateTransformedTime(3, 1000, 600, {_easingFunction: function(x) { return x * x; }, direction: 'alternate'}), 160, 0.0001);
+    assert.closeTo(calculateTransformedTime(4, 1000, 600, {_easingFunction: function(x) { return x * x; }, direction: 'alternate-reverse'}), 160, 0.0001);
+    assert.closeTo(calculateTransformedTime(3, 1000, 600, {_easingFunction: function(x) { return x * x; }, direction: 'alternate-reverse'}), 360, 0.0001);
   });
   test('EffectTime', function() {
     var timing = normalizeTimingInput({duration: 1000, iterations: 4, iterationStart: 0.5, easing: 'linear', direction: 'alternate', delay: 100, fill: 'forwards'});


### PR DESCRIPTION
Make invalid easings in animation timing inputs throw a TypeError.
This matches spec behaviour: http://w3c.github.io/web-animations/#dom-animationeffecttiming-easing

This change depends on #423 merging first.