### PR TITLE
added closure-linter-wrapper, required by gjslint.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "mocha": "1.21.4",
     "chai": "^1.9.1",
+    "closure-linter-wrapper": "^1.0.1",
     "grunt": "~0.4.5",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-gjslint": "^0.1.4",
@@ -34,7 +35,6 @@
     "karma-sauce-launcher": "~0.2.3",
     "grunt-checkrepo": "~0.1.0",
     "grunt-saucelabs": "~4.0.2",
-    "grunt-checkrepo": "~0.1.0",
     "grunt-git-status": "~1.0.0",
     "grunt-template": "~0.2.3",
     "source-map": "~0.1.40"


### PR DESCRIPTION
Clean `npm install` and `grunt` fails without this, complaining it doesn't exist. This is just the change after running `npm install --save closure-linter-wrapper`.

