### PR TITLE
Increase Bezier timing function accuracy

### DIFF
--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -168,7 +168,7 @@
         var mid = (start + end) / 2;
         function f(a, b, m) { return 3 * a * (1 - m) * (1 - m) * m + 3 * b * (1 - m) * m * m + m * m * m};
         var xEst = f(a, c, mid);
-        if (Math.abs(x - xEst) < 0.001) {
+        if (Math.abs(x - xEst) < 0.0001) {
           return f(b, d, mid);
         }
         if (xEst < x) {

--- a/test/js/timing-utilities.js
+++ b/test/js/timing-utilities.js
@@ -23,15 +23,15 @@ suite('timing-utilities', function() {
     var f = toTimingFunction('ease');
     var g = toTimingFunction('cubic-bezier(.25, 0.1, 0.25, 1.0)');
     assertTimingFunctionsEqual(f, g, 'ease should map onto preset cubic-bezier');
-    assert.closeTo(f(0.1844), 0.2601, 0.01);
-    assert.closeTo(g(0.1844), 0.2601, 0.01);
+    assert.closeTo(f(0.1844), 0.2599, 0.001);
+    assert.closeTo(g(0.1844), 0.2599, 0.001);
     assert.equal(f(0), 0);
     assert.equal(f(1), 1);
     assert.equal(g(0), 0);
     assert.equal(g(1), 1);
 
     f = toTimingFunction('cubic-bezier(0, 1, 1, 0)');
-    assert.closeTo(f(0.104), 0.392, 0.01);
+    assert.closeTo(f(0.104), 0.3920, 0.001);
 
     function assertIsLinear(easing) {
       var f = toTimingFunction(easing);


### PR DESCRIPTION
The polyfill evaluation of cubic Bezier timing functions
gives slightly different results than the native Blink
implementation.

In my testing, this change reduced the absolute error by 63%
while only increasing the number of cubic function evaluations
by 31%

This closes #139