### PR TITLE
Add missing 2.2.0 version history

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,36 @@
+### 2.2.0 - *April 6 2016*
+  * Deprecated the use of hyphens in property names.
+
+    For example, this is deprecated:
+
+        element.animate([{'font-size': '0px'}, {'font-size': '10px'}]);
+
+    and this should be used instead:
+
+        element.animate([{fontSize: '0px'}, {fontSize: '10px'}]);
+
+  * Added arbitrary easing capitalisation.
+
+  * Added "id" effect option. (http://w3c.github.io/web-animations/#dom-keyframeanimationoptions-id)
+
+  * Added "oncancel" event handler.
+
+  * Added value list keyframe syntax.
+
+    As as alternative to:
+
+        element.animate([{color: 'red'}, {color: 'green'}, {color: 'blue'}]);
+
+    you can now use:
+
+        element.animate({color: ['red', 'green', 'blue']});
+
+  * Fixed easing TypeError in FireFox Nightly when using groups.
+
+  * Fixed delayed animation updates on Safari and Firefox
+
+  * Fixed infinite recursion when setting onfinish to null.
+
 ### 2.1.4 - *December 1 2015*
   * Use `Date.now()` instead of `performace.now()` for mobile Safari.
 


### PR DESCRIPTION
This was left out from web-animations-next in the 2.2.0 release.