### PR TITLE
Deprecate invalid timing inputs instead of throwing TypeErrors immediately

### DIFF
--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -17,6 +17,10 @@
   var silenced = {};
 
   shared.isDeprecated = function(feature, date, advice, plural) {
+    if (WEB_ANIMATIONS_TESTING) {
+      return true;
+    }
+
     var auxVerb = plural ? 'are' : 'is';
     var today = new Date();
     var expiry = new Date(date);

--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -80,10 +80,8 @@
       return this._fill;
     },
     set iterationStart(value) {
-      if (isNaN(value) || value < 0) {
-        if (isInvalidTimingDeprecated()) {
-          throw new TypeError('iterationStart must be a non-negative number, received: ' + timing.iterationStart);
-        }
+      if ((isNaN(value) || value < 0) && isInvalidTimingDeprecated()) {
+        throw new TypeError('iterationStart must be a non-negative number, received: ' + timing.iterationStart);
       }
       this._setMember('iterationStart', value);
     },
@@ -91,10 +89,8 @@
       return this._iterationStart;
     },
     set duration(value) {
-      if (value != 'auto' && (isNaN(value) || value < 0)) {
-        if (isInvalidTimingDeprecated()) {
-          throw new TypeError('duration must be non-negative or auto, received: ' + value);
-        }
+      if (value != 'auto' && (isNaN(value) || value < 0) && isInvalidTimingDeprecated()) {
+        throw new TypeError('duration must be non-negative or auto, received: ' + value);
       }
       this._setMember('duration', value);
     },
@@ -115,10 +111,8 @@
       return this._easing;
     },
     set iterations(value) {
-      if (isNaN(value) || value < 0) {
-        if (isInvalidTimingDeprecated()) {
-          throw new TypeError('iterations must be non-negative, received: ' + value);
-        }
+      if ((isNaN(value) || value < 0) && isInvalidTimingDeprecated()) {
+        throw new TypeError('iterations must be non-negative, received: ' + value);
       }
       this._setMember('iterations', value);
     },

--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -42,6 +42,10 @@
     this._easingFunction = linear;
   }
 
+  function isInvalidTimingDeprecated() {
+    return shared.isDeprecated('Invalid timing inputs', '2016-03-02', 'TypeError exceptions will be thrown instead.', true);
+  }
+
   AnimationEffectTiming.prototype = {
     _setMember: function(member, value) {
       this['_' + member] = value;
@@ -77,7 +81,9 @@
     },
     set iterationStart(value) {
       if (isNaN(value) || value < 0) {
-        throw new TypeError('iterationStart must be a non-negative number, received: ' + timing.iterationStart);
+        if (isInvalidTimingDeprecated()) {
+          throw new TypeError('iterationStart must be a non-negative number, received: ' + timing.iterationStart);
+        }
       }
       this._setMember('iterationStart', value);
     },
@@ -86,7 +92,9 @@
     },
     set duration(value) {
       if (value != 'auto' && (isNaN(value) || value < 0)) {
-        throw new TypeError('duration must be non-negative or auto, received: ' + value);
+        if (isInvalidTimingDeprecated()) {
+          throw new TypeError('duration must be non-negative or auto, received: ' + value);
+        }
       }
       this._setMember('duration', value);
     },
@@ -108,7 +116,9 @@
     },
     set iterations(value) {
       if (isNaN(value) || value < 0) {
-        throw new TypeError('iterations must be non-negative, received: ' + value);
+        if (isInvalidTimingDeprecated()) {
+          throw new TypeError('iterations must be non-negative, received: ' + value);
+        }
       }
       this._setMember('iterations', value);
     },
@@ -228,7 +238,7 @@
     styleForCleaning.animationTimingFunction = easing;
     var validatedEasing = styleForCleaning.animationTimingFunction;
 
-    if (validatedEasing == '') {
+    if (validatedEasing == '' && isInvalidTimingDeprecated()) {
       throw new TypeError(easing + ' is not a valid value for easing');
     }
 


### PR DESCRIPTION
Deprecation is a temporary communication signal to users of the polyfill rather than a hard exception that halts JS execution.