### PR TITLE
Add missing catch block to object form support test

### DIFF
--- a/src/web-animations-bonus-object-form-keyframes.js
+++ b/src/web-animations-bonus-object-form-keyframes.js
@@ -38,6 +38,7 @@
         {duration: 1});
     animation.currentTime = 0;
     animated = getComputedStyle(element).getPropertyValue('opacity') == testOpacity;
+  } catch (error) {
   } finally {
     if (animation)
       animation.cancel();


### PR DESCRIPTION
The catch statement was missing from https://github.com/web-animations/web-animations-next/pull/434, this change adds it so that errors indicate no support instead of propagating out of the polyfill.
Verified manually.