### PR TITLE
Remove references to window.document.timeline

### DIFF
--- a/src/keyframe-effect-constructor.js
+++ b/src/keyframe-effect-constructor.js
@@ -164,11 +164,11 @@
     configurable: true,
     enumerable: true,
     value: function() {
-      window.document.timeline._updateAnimationsPromises();
+      scope.timeline._updateAnimationsPromises();
       var result = originalGetComputedStyle.apply(this, arguments);
       if (updatePendingGroups())
         result = originalGetComputedStyle.apply(this, arguments);
-      window.document.timeline._updateAnimationsPromises();
+      scope.timeline._updateAnimationsPromises();
       return result;
     },
   });

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -17,9 +17,9 @@
   var originalRequestAnimationFrame = window.requestAnimationFrame;
   window.requestAnimationFrame = function(f) {
     return originalRequestAnimationFrame(function(x) {
-      window.document.timeline._updateAnimationsPromises();
+      scope.timeline._updateAnimationsPromises();
       f(x);
-      window.document.timeline._updateAnimationsPromises();
+      scope.timeline._updateAnimationsPromises();
     });
   };
 
@@ -76,7 +76,7 @@
   };
 
   function webAnimationsNextTick(t) {
-    var timeline = window.document.timeline;
+    var timeline = scope.timeline;
     timeline.currentTime = t;
     timeline._discardAnimations();
     if (timeline._animations.length == 0)

--- a/src/web-animations-next-animation.js
+++ b/src/web-animations-next-animation.js
@@ -139,7 +139,7 @@
       var offset = this.effect._timing.delay;
       this._removeChildAnimations();
       this.effect.children.forEach(function(child) {
-        var childAnimation = window.document.timeline._play(child);
+        var childAnimation = scope.timeline._play(child);
         this._childAnimations.push(childAnimation);
         childAnimation.playbackRate = this.playbackRate;
         if (this._paused)


### PR DESCRIPTION
We now use the internal reference scope.timeline.

Closes #376