### PR TITLE
Add grunt-gjslint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt": "~0.4.5",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-gjslint": "^0.1.4",
+    "closure-linter-wrapper": "~0.2.0",
     "grunt-karma": "^0.8.2",
     "karma": "^0.12.14",
     "karma-mocha": "^0.1.3",


### PR DESCRIPTION
closure-linter-wrapper is a required dependency of the grunt-gjslint plugin package.
npm install on a fresh checkout fails if this dependency isn't made explicit.