### PR TITLE
Valid SPDB license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "polyfill"
   ],
   "homepage": "https://github.com/web-animations",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "main": "web-animations.min.js",
   "files": [
     "*.min.js",


### PR DESCRIPTION
npm install was reporting a warning:
  license should be a valid SPDX license expression

Avoid by using Apache-2.0 as specified in http://spdx.org/licenses/