### PR TITLE
Change Travis config to test on Firefox stable instead of aurora

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -81,12 +81,14 @@ Chrome)
 Firefox)
   sudo rm -f /usr/local/bin/firefox
   case $VERSION in
+  stable)
+    ;;
   beta)
     yes "\n" | sudo add-apt-repository -y ppa:mozillateam/firefox-next
     ;;
-  aurora)
-    yes "\n" | sudo add-apt-repository -y ppa:ubuntu-mozilla-daily/firefox-aurora
-    ;;
+  # TODO(alancutter): Add support for firefox-aurora.
+  # This will need to download the binary manually as the ubuntu-mozilla-daily
+  # ppa doesn't support the version of linux that Travis uses.
   esac
   sudo apt-get update --fix-missing
   sudo apt-get install firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
  - "4.4.4"
 
 install:
-  - BROWSER="Firefox-aurora" ./.travis-setup.sh
+  - BROWSER="Firefox-stable" ./.travis-setup.sh
 
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
The Travis setup for Firefox Aurora is currently broken because the ppa:ubuntu-mozilla-daily/firefox-aurora repository doesn't have the latest version of Firefox for the version of Linux that Travis uses (Precise).

https://launchpad.net/~ubuntu-mozilla-daily/+archive/ubuntu/firefox-aurora/+packages?field.name_filter=&field.status_filter=published&field.series_filter=precise
The package build fails with `ERROR: Only GCC 4.8 or newer is supported (found version 4.6.3).`.

This change removes the Firefox-aurora option and sets Travis to Firefox-stable so that it is less misleading.