### PR TITLE
Add the ability to test a given list of files to `grunt test/debug`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,13 @@
 
 You can run the tests in an interactive mode with `grunt debug`. This starts the
 Karma server once for each polyfill target for each test framework.
-Navigate to [http://localhost:9876/debug.html]() to open the test runner in your
+Navigate to `http://localhost:9876/debug.html` to open the test runner in your
 browser of choice, all test results appear in the Javascript console.
 
 The polyfill target and tests can be specified as arguments to the `debug` task.  
 Example: `grunt debug:web-animations-next:test/web-platform-tests/web-animations/animation/pause.html`  
 Multiple test files may be listed with comma separation. Specifying files will output their URL in the command line.  
-Example: [http://localhost:9876/base/test/web-platform-tests/web-animations/animation/pause.html]()
+Example: `http://localhost:9876/base/test/web-platform-tests/web-animations/animation/pause.html`
 
 
 ## Design notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,24 @@
 1. Run `grunt test` to run polyfill and web-platform-tests tests.
 
 
+## Debugging tests
+
+You can run the tests in an interactive mode with `grunt debug`. This starts the
+Karma server once for each polyfill target for each test framework. Press DEBUG
+to run the tests in a new tab, press Ctrl-C on the command line to move to the next
+polyfill target/test framework.
+
+While the Karma server is running you may point any browser to the served URL. Files
+in the repository are located at http://localhost:9876/base/\<path\>.
+Example: http://localhost:9876/base/test/web-platform-tests/web-animations/animation/pause.html
+Unfortunately Karma doesn't serve file lists for directories, files need to be navigated to directly.
+
+The polyfill target and tests can be specified as arguments to the `debug` task.
+Example: `grunt debug:web-animations-next:test/web-platform-tests/web-animations/animation/pause.html`
+will run just the pause.html test on the web-animations-next polyfill when you click DEBUG.  
+Multiple test files may be listed with comma separation.
+
+
 ## Design notes
 
 [Design diagrams](https://drive.google.com/folderview?id=0B9rpPoIDv3vTNlZxOVp6a2tNa1E&usp=sharing)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,19 +12,14 @@
 ## Debugging tests
 
 You can run the tests in an interactive mode with `grunt debug`. This starts the
-Karma server once for each polyfill target for each test framework. Press DEBUG
-to run the tests in a new tab, press Ctrl-C on the command line to move to the next
-polyfill target/test framework.
+Karma server once for each polyfill target for each test framework.
+Navigate to [http://localhost:9876/debug.html]() to open the test runner in your
+browser of choice, all test results appear in the Javascript console.
 
-While the Karma server is running you may point any browser to the served URL. Files
-in the repository are located at http://localhost:9876/base/\<path\>.
-Example: http://localhost:9876/base/test/web-platform-tests/web-animations/animation/pause.html
-Unfortunately Karma doesn't serve file lists for directories, files need to be navigated to directly.
-
-The polyfill target and tests can be specified as arguments to the `debug` task.
-Example: `grunt debug:web-animations-next:test/web-platform-tests/web-animations/animation/pause.html`
-will run just the pause.html test on the web-animations-next polyfill when you click DEBUG.  
-Multiple test files may be listed with comma separation.
+The polyfill target and tests can be specified as arguments to the `debug` task.  
+Example: `grunt debug:web-animations-next:test/web-platform-tests/web-animations/animation/pause.html`  
+Multiple test files may be listed with comma separation. Specifying files will output their URL in the command line.  
+Example: [http://localhost:9876/base/test/web-platform-tests/web-animations/animation/pause.html]()
 
 
 ## Design notes

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -276,9 +276,16 @@ module.exports = function(grunt) {
   });
 
   grunt.task.registerMultiTask('debug', 'Debug <target> tests under Karma', function(testFilter) {
-    var chalk = require('chalk');
-    console.log(chalk.inverse('>>> Press "DEBUG" in the web page to run tests and Ctrl-C here to finish. <<<'));
+    if (testFilter) {
+      console.log('Test file URLs:');
+      for (var testFile of testFilter.split(',')) {
+        console.log('http://localhost:9876/base/' + testFile);
+      }
+    } else {
+      console.log('Test runner URL: http://localhost:9876/debug.html');
+    }
     runTests(this, function(karmaConfig) {
+      karmaConfig.browsers = [];
       karmaConfig.singleRun = false;
     }, testFilter);
   });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "mocha": "1.21.4",
     "chai": "^1.9.1",
-    "chalk": "^1.1.3",
     "grunt": "~0.4.5",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-gjslint": "^0.1.4",


### PR DESCRIPTION
This change adds a new parameter to `grunt test` and `grunt debug`.
You can now run specific test files e.g. `grunt debug:web-animations-next:test/web-platform-tests/web-animations/animation/pause.html`.

This change also makes `grunt debug` not launch the Firefox browser, instead it just starts the Karma server and provides a URL for you to navigate to.