### PR TITLE
Test web-animations target with subset of web-platform-tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "test/web-platform-tests"]
-	path = test/web-platform-tests
-	url = https://github.com/w3c/web-platform-tests.git
+  path = test/web-platform-tests
+  url = https://github.com/alancutter/web-platform-tests.git
+  branch = nativeShippingAPI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ You can run the tests in an interactive mode with `grunt debug`. This starts the
 Karma server once for each polyfill target for each test framework.
 Navigate to `http://localhost:9876/debug.html` to open the test runner in your
 browser of choice, all test results appear in the Javascript console.
+Test failures can be accessed via `window.failures` and `window.formattedFailures`
+once the tests have completed.
 
 The polyfill target and tests can be specified as arguments to the `debug` task.  
 Example: `grunt debug:web-animations-next:test/web-platform-tests/web-animations/animation/pause.html`  

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -237,6 +237,7 @@ module.exports = function(grunt) {
         configCallback(karmaConfig);
         karmaConfig.client.testharnessTests = require('./test/web-platform-tests-expectations.js');
         karmaConfig.client.testharnessTests.testURLList = testFiles;
+        karmaConfig.proxies['/polyfill.js'] = '/base/' + task.target + '.min.js';
         karmaConfig.files.push('test/karma-testharness-adapter.js');
         var servedFiles = [
           'test/web-platform-tests/resources/**',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,11 +227,7 @@ module.exports = function(grunt) {
       });
     }
     function runWebPlatformTests() {
-      if (!config.runWebPlatformTests) {
-        return Promise.resolve(true);
-      }
-
-      var testFiles = filterTests(grunt.file.expand('test/web-platform-tests/web-animations/**/*.html'));
+      var testFiles = filterTests(grunt.file.expand(config.webPlatformTests));
       if (testFiles.length == 0) {
         return Promise.resolve(true);
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "source-map": "~0.1.40"
   },
   "scripts": {
-    "test": "grunt test gjslint git-status checkrepo"
+    "test": "grunt web-animations web-animations-next test gjslint git-status checkrepo"
   }
 }

--- a/target-config.js
+++ b/target-config.js
@@ -110,6 +110,26 @@
       'test/js/timeline.js',
       'test/js/web-animations-next-animation.js');
 
+  var webAnimations1WebPlatformTests = [
+    'test/web-platform-tests/web-animations/animation-model/animation-types/discrete-animation.html',
+    'test/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context.html',
+    'test/web-platform-tests/web-animations/animation-model/keyframe-effects/the-effect-value-of-a-keyframe-effect.html',
+    'test/web-platform-tests/web-animations/interfaces/Animatable/animate-basic.html',
+    'test/web-platform-tests/web-animations/interfaces/Animation/cancel.html',
+    'test/web-platform-tests/web-animations/interfaces/Animation/id.html',
+    'test/web-platform-tests/web-animations/interfaces/Animation/pause.html',
+    'test/web-platform-tests/web-animations/interfaces/Animation/play.html',
+    'test/web-platform-tests/web-animations/interfaces/Animation/playState.html',
+    'test/web-platform-tests/web-animations/interfaces/Animation/startTime.html',
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/effect-easing.html',
+    'test/web-platform-tests/web-animations/timing-model/animation-effects/active-time.html',
+    'test/web-platform-tests/web-animations/timing-model/animation-effects/simple-iteration-progress.html',
+  ];
+
+  var webAnimationsNextWebPlatformTests = [
+    'test/web-platform-tests/web-animations/**/*.html',
+  ];
+
   // This object specifies the source and test files for different Web Animation build targets.
   var targetConfig = {
     'web-animations': {
@@ -120,7 +140,7 @@
       webAnimationsNextSrc: [],
       src: scopeSrc.concat(sharedSrc).concat(webAnimations1Src).concat(webAnimations1BonusSrc),
       polyfillTests: webAnimations1PolyfillTests,
-      runWebPlatformTests: false,
+      webPlatformTests: webAnimations1WebPlatformTests,
     },
     'web-animations-next': {
       scopeSrc: scopeSrc,
@@ -130,7 +150,7 @@
       webAnimationsNextSrc: webAnimationsNextSrc,
       src: scopeSrc.concat(sharedSrc).concat(webAnimations1Src).concat(webAnimations1BonusSrc).concat(webAnimationsNextSrc),
       polyfillTests: webAnimationsNextPolyfillTests,
-      runWebPlatformTests: true,
+      webPlatformTests: webAnimationsNextWebPlatformTests,
     },
     'web-animations-next-lite': {
       scopeSrc: scopeSrc,
@@ -140,7 +160,7 @@
       webAnimationsNextSrc: webAnimationsNextSrc,
       src: scopeSrc.concat(sharedSrc).concat(liteWebAnimations1Src).concat(webAnimations1BonusSrc).concat(webAnimationsNextSrc),
       polyfillTests: [],
-      runWebPlatformTests: false,
+      webPlatformTests: [],
     },
   };
 

--- a/test/karma-config.js
+++ b/test/karma-config.js
@@ -21,7 +21,6 @@ module.exports = function(config) {
       '/resources/WebIDLParser.js': '/base/test/web-platform-tests/resources/webidl2/lib/webidl2.js',
 
       '/test/': '/base/test/',
-      '/polyfill/': '/base/',
     },
   });
 };

--- a/test/karma-testharness-adapter.js
+++ b/test/karma-testharness-adapter.js
@@ -130,13 +130,13 @@
       var tests = Object.keys(failures[testURL]);
       tests.sort();
       return (
-        '    ' + stringify(testURL) + ': {\n' +
-        tests.map(function(test) {
-          return (
-            '      ' + stringify(test) + ':\n' +
-            '          ' + stringify(failures[testURL][test]) + ',\n');
-        }).join('\n') +
-        '    },\n');
+          '    ' + stringify(testURL) + ': {\n' +
+          tests.map(function(test) {
+            return (
+                '      ' + stringify(test) + ':\n' +
+                '          ' + stringify(failures[testURL][test]) + ',\n');
+          }).join('\n') +
+          '    },\n');
     }).join('\n');
   }
 

--- a/test/resources/testharnessreport.js
+++ b/test/resources/testharnessreport.js
@@ -406,9 +406,8 @@ function dump_test_results(tests, status) {
 }
 
 /* BEGIN WEB ANIMATIONS POLYFILL EXTRAS */
-// TODO(alancutter): Use a generic script injection method to allow grunt to choose what
-// version of the polyfill to load for testing.
-document.write('<script src="/polyfill/web-animations-next.dev.js"></script>');
+// The path /polyfill.js is expected to be a proxy for the appropriate polyfill script configured in Karma.
+document.write('<script src="/polyfill.js"></script>');
 if (window.parent && parent.window.onTestharnessLoaded) {
     parent.window.onTestharnessLoaded(window);
 } else {

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -11,70 +11,32 @@ module.exports = {
   flakyTestIndicator: 'FLAKY_TEST_RESULT',
   expectedFailures: {
     'test/web-platform-tests/web-animations/animatable/animate.html': {
-      // Serialization of objects cannot be feasibly overwritten by the polyfill.
-      'Element.animate() creates an Animation object':
-          'assert_equals: Returned object is an Animation expected "[object Animation]" but got "[object Object]"',
+      'CSSPseudoElement.animate() creates an Animation object':
+          'document.getAnimations is not a function',
 
-      // Serialization of objects cannot be feasibly overwritten by the polyfill.
-      'Element.animate() creates an Animation object with a KeyframeEffect':
-          'assert_equals: Returned Animation has a KeyframeEffect expected "[object KeyframeEffect]" but got "[object Object]"',
+      'CSSPseudoElement.animate() creates an Animation object targeting to the correct CSSPseudoElement object':
+          'document.getAnimations is not a function',
 
-      'Element.animate() accepts a one property two value property-indexed keyframes specification':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+      'Element.animate() accepts a double as an options argument':
+          'assert_equals: expected "auto" but got "none"',
 
-      'Element.animate() accepts a one shorthand property two value property-indexed keyframes specification':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+      'Element.animate() accepts a keyframe sequence where greater shorthand precedes lesser shorthand':
+          'assert_equals: properties on ComputedKeyframe #0 expected "border,borderLeft,computedOffset,easing,offset" but got "borderBottomColor,borderBottomStyle,borderBottomWidth,borderLeftColor,borderLeftStyle,borderLeftWidth,borderRightColor,borderRightStyle,borderRightWidth,borderTopColor,borderTopStyle,borderTopWidth,offset"',
 
-      'Element.animate() accepts a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
-          'assert_equals: number of frames expected 2 but got 4',
+      'Element.animate() accepts a keyframe sequence where lesser shorthand precedes greater shorthand':
+          'assert_equals: properties on ComputedKeyframe #0 expected "border,borderLeft,computedOffset,easing,offset" but got "borderBottomColor,borderBottomStyle,borderBottomWidth,borderLeftColor,borderLeftStyle,borderLeftWidth,borderRightColor,borderRightStyle,borderRightWidth,borderTopColor,borderTopStyle,borderTopWidth,offset"',
 
-      'Element.animate() accepts a two property two value property-indexed keyframes specification':
-          'assert_equals: number of frames expected 2 but got 4',
+      'Element.animate() accepts a keyframe sequence where longhand precedes shorthand':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginRight,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
 
-      'Element.animate() accepts a two property property-indexed keyframes specification with different numbers of values':
-          'assert_equals: number of frames expected 3 but got 5',
+      'Element.animate() accepts a keyframe sequence where shorthand precedes longhand':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginRight,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
 
-      'Element.animate() accepts a property-indexed keyframes specification with an invalid value':
-          'assert_equals: number of frames expected 5 but got 10',
+      'Element.animate() accepts a keyframe sequence with different composite values, but the same composite value for a given offset':
+          'add compositing is not supported',
 
-      'Element.animate() accepts a one property two value property-indexed keyframes specification that needs to stringify its values':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,offset,opacity" but got "offset,opacity"',
-
-      'Element.animate() accepts a one property one value property-indexed keyframes specification':
-          'Partial keyframes are not supported',
-
-      'Element.animate() accepts a one property one non-array value property-indexed keyframes specification':
-          'Partial keyframes are not supported',
-
-      'Element.animate() accepts a one property two value property-indexed keyframes specification where the first value is invalid':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
-
-      'Element.animate() accepts a one property two value property-indexed keyframes specification where the second value is invalid':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
-
-      'Element.animate() accepts a two property property-indexed keyframes specification where one property is missing from the first keyframe':
-          'Partial keyframes are not supported',
-
-      'Element.animate() accepts a two property property-indexed keyframes specification where one property is missing from the last keyframe':
-          'Partial keyframes are not supported',
-
-      'Element.animate() accepts a property-indexed keyframes specification with repeated values at offset 0 with different easings':
+      'Element.animate() accepts a keyframe sequence with different easing values, but the same easing value for a given offset':
           'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "easing,left,offset"',
-
-      'Element.animate() accepts a one property one keyframe sequence':
-          'Partial keyframes are not supported',
-
-      'Element.animate() accepts a one property two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
-
-      'Element.animate() accepts a two property two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset,top" but got "left,offset,top"',
-
-      'Element.animate() accepts a one shorthand property two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
-
-      'Element.animate() accepts a two property (a shorthand and one of its component longhands) two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginTop,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
 
       'Element.animate() accepts a keyframe sequence with duplicate values for a given interior offset':
           'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
@@ -82,62 +44,80 @@ module.exports = {
       'Element.animate() accepts a keyframe sequence with duplicate values for offsets 0 and 1':
           'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
 
-      'Element.animate() accepts a two property four keyframe sequence':
+      'Element.animate() accepts a one property keyframe sequence with all omitted offsets':
           'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+
+      'Element.animate() accepts a one property keyframe sequence with some omitted offsets':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+
+      'Element.animate() accepts a one property one keyframe sequence':
+          'Partial keyframes are not supported',
+
+      'Element.animate() accepts a one property one non-array value property-indexed keyframes specification':
+          'Partial keyframes are not supported',
+
+      'Element.animate() accepts a one property one value property-indexed keyframes specification':
+          'Partial keyframes are not supported',
+
+      'Element.animate() accepts a one property two keyframe sequence':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+
+      'Element.animate() accepts a one property two keyframe sequence that needs to stringify its values':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,offset,opacity" but got "offset,opacity"',
+
+      'Element.animate() accepts a one property two value property-indexed keyframes specification':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+
+      'Element.animate() accepts a one property two value property-indexed keyframes specification that needs to stringify its values':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,offset,opacity" but got "offset,opacity"',
+
+      'Element.animate() accepts a one property two value property-indexed keyframes specification where the first value is invalid':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+
+      'Element.animate() accepts a one property two value property-indexed keyframes specification where the second value is invalid':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+
+      'Element.animate() accepts a one shorthand property two keyframe sequence':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+
+      'Element.animate() accepts a one shorthand property two value property-indexed keyframes specification':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+
+      'Element.animate() accepts a property-indexed keyframes specification with an invalid value':
+          'assert_equals: number of frames expected 5 but got 10',
+
+      'Element.animate() accepts a property-indexed keyframes specification with repeated values at offset 0 with different easings':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "easing,left,offset"',
 
       'Element.animate() accepts a single keyframe sequence with omitted offsets':
           'Partial keyframes are not supported',
 
-      'Element.animate() accepts a one property keyframe sequence with some omitted offsets':
+      'Element.animate() accepts a two property (a shorthand and one of its component longhands) two keyframe sequence':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginTop,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+
+      'Element.animate() accepts a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
+          'assert_equals: number of frames expected 2 but got 4',
+
+      'Element.animate() accepts a two property four keyframe sequence':
           'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
 
       'Element.animate() accepts a two property keyframe sequence with some omitted offsets':
           'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset,top" but got "left,offset,top"',
 
-      'Element.animate() accepts a one property keyframe sequence with all omitted offsets':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+      'Element.animate() accepts a two property property-indexed keyframes specification where one property is missing from the first keyframe':
+          'Partial keyframes are not supported',
 
-      'Element.animate() accepts a keyframe sequence with different easing values, but the same easing value for a given offset':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "easing,left,offset"',
+      'Element.animate() accepts a two property property-indexed keyframes specification where one property is missing from the last keyframe':
+          'Partial keyframes are not supported',
 
-      'Element.animate() accepts a keyframe sequence with different composite values, but the same composite value for a given offset':
-          'add compositing is not supported',
+      'Element.animate() accepts a two property property-indexed keyframes specification with different numbers of values':
+          'assert_equals: number of frames expected 3 but got 5',
 
-      'Element.animate() accepts a one property two keyframe sequence that needs to stringify its values':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,offset,opacity" but got "offset,opacity"',
+      'Element.animate() accepts a two property two keyframe sequence':
+          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset,top" but got "left,offset,top"',
 
-      'Element.animate() accepts a keyframe sequence where shorthand precedes longhand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginRight,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
-
-      'Element.animate() accepts a keyframe sequence where longhand precedes shorthand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginRight,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
-
-      'Element.animate() accepts a keyframe sequence where lesser shorthand precedes greater shorthand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "border,borderLeft,computedOffset,easing,offset" but got "borderBottomColor,borderBottomStyle,borderBottomWidth,borderLeftColor,borderLeftStyle,borderLeftWidth,borderRightColor,borderRightStyle,borderRightWidth,borderTopColor,borderTopStyle,borderTopWidth,offset"',
-
-      'Element.animate() accepts a keyframe sequence where greater shorthand precedes lesser shorthand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "border,borderLeft,computedOffset,easing,offset" but got "borderBottomColor,borderBottomStyle,borderBottomWidth,borderLeftColor,borderLeftStyle,borderLeftWidth,borderRightColor,borderRightStyle,borderRightWidth,borderTopColor,borderTopStyle,borderTopWidth,offset"',
-
-      'Element.animate() does not accept keyframes with an out-of-bounded positive offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
-
-      'Element.animate() does not accept keyframes with an out-of-bounded negative offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
-
-      'Element.animate() does not accept keyframes not loosely sorted by offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." threw object "[object Object]" ("InvalidModificationError") expected object "[object Object]" ("TypeError")',
-
-      'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
-
-      'Element.animate() does not accept a keyframe sequence with an invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
-
-      'Element.animate() does not accept keyframes with an invalid composite value':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." threw object "[object Object]" ("NotSupportedError") expected object "[object Object]" ("TypeError")',
-
-      'Element.animate() accepts a double as an options argument':
-          'assert_equals: expected "auto" but got "none"',
+      'Element.animate() accepts a two property two value property-indexed keyframes specification':
+          'assert_equals: number of frames expected 2 but got 4',
 
       'Element.animate() accepts an absent options argument':
           'assert_equals: expected (string) "auto" but got (number) 0',
@@ -145,56 +125,50 @@ module.exports = {
       'Element.animate() correctly sets the Animation\'s timeline when triggered on an element in a different document':
           'div.animate is not a function',
 
-      'CSSPseudoElement.animate() creates an Animation object':
-          'document.getAnimations is not a function',
+      'Element.animate() creates an Animation object':
+          'assert_equals: Returned object is an Animation expected "[object Animation]" but got "[object Object]"',
 
-      'CSSPseudoElement.animate() creates an Animation object targeting to the correct CSSPseudoElement object':
-          'document.getAnimations is not a function',
+      'Element.animate() creates an Animation object with a KeyframeEffect':
+          'assert_equals: Returned Animation has a KeyframeEffect expected "[object KeyframeEffect]" but got "[object Object]"',
+
+      'Element.animate() does not accept keyframes not loosely sorted by offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." threw object "[object Object]" ("InvalidModificationError") expected object "[object Object]" ("TypeError")',
+
+      'Element.animate() does not accept keyframes with an invalid composite value':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." threw object "[object Object]" ("NotSupportedError") expected object "[object Object]" ("TypeError")',
+
+      'Element.animate() does not accept keyframes with an out-of-bounded negative offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
+
+      'Element.animate() does not accept keyframes with an out-of-bounded positive offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
+
+      'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/delay.html': {
-      'set delay 100':
-          'anim.effect.getComputedTiming is not a function',
-
-      'set delay -100':
-          'anim.effect.getComputedTiming is not a function',
-
       'Test adding a positive delay to an animation without a backwards fill makes it no longer active':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test finishing an animation using a large negative delay':
           'anim.effect.getComputedTiming is not a function',
 
       'Test seeking an animation by setting a negative delay':
           'anim.effect.getComputedTiming is not a function',
 
-      'Test finishing an animation using a large negative delay':
+      'set delay -100':
+          'anim.effect.getComputedTiming is not a function',
+
+      'set delay 100':
           'anim.effect.getComputedTiming is not a function',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/duration.html': {
-      'set duration 123.45':
-          'anim.effect.getComputedTiming is not a function',
-
-      'set duration auto':
-          'anim.effect.getComputedTiming is not a function',
-
-      'set auto duration in animate as object':
-          'assert_equals: set duration \'auto\' expected (string) "auto" but got (number) 0',
-
-      'set duration Infinity':
-          'anim.effect.getComputedTiming is not a function',
-
-      'set negative duration in animate using a duration parameter':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
-
-      'set negative Infinity duration in animate using a duration parameter':
+      'set 100 string duration in animate using an options object':
           'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
 
       'set NaN duration in animate using a duration parameter':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
-
-      'set negative duration in animate using an options object':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
-
-      'set negative Infinity duration in animate using an options object':
           'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
 
       'set NaN duration in animate using an options object':
@@ -203,34 +177,25 @@ module.exports = {
       'set abc string duration in animate using an options object':
           'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
 
-      'set 100 string duration in animate using an options object':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
+      'set auto duration in animate as object':
+          'assert_equals: set duration \'auto\' expected (string) "auto" but got (number) 0',
 
-      'set negative duration':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.durat..." did not throw',
+      'set duration 123.45':
+          'anim.effect.getComputedTiming is not a function',
 
-      'set negative Infinity duration':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.durat..." did not throw',
+      'set duration Infinity':
+          'anim.effect.getComputedTiming is not a function',
 
-      'set NaN duration':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.durat..." did not throw',
-
-      'set duration abc':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.durat..." did not throw',
+      'set duration auto':
+          'anim.effect.getComputedTiming is not a function',
 
       'set duration string 100':
           'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.durat..." did not throw',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/easing.html': {
-      'steps(start) function':
-          'animation.effect.getComputedTiming is not a function',
-
-      'steps(end) function':
-          'animation.effect.getComputedTiming is not a function',
-
-      'linear function':
-          'animation.effect.getComputedTiming is not a function',
+      'Change the easing while the animation is running':
+          'anim.effect.getComputedTiming is not a function',
 
       'ease function':
           'animation.effect.getComputedTiming is not a function',
@@ -247,18 +212,24 @@ module.exports = {
       'easing function which produces values greater than 1':
           'animation.effect.getComputedTiming is not a function',
 
-      'Test invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n                  anim.effec..." did not throw',
+      'linear function':
+          'animation.effect.getComputedTiming is not a function',
 
-      'Change the easing while the animation is running':
-          'anim.effect.getComputedTiming is not a function',
+      'steps(end) function':
+          'animation.effect.getComputedTiming is not a function',
+
+      'steps(start) function':
+          'animation.effect.getComputedTiming is not a function',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/endDelay.html': {
-      'set endDelay 123.45':
-          'anim.effect.getComputedTiming is not a function',
+      'onfinish event is fired currentTime is after endTime':
+          'FLAKY_TEST_RESULT',
 
       'set endDelay -1000':
+          'anim.effect.getComputedTiming is not a function',
+
+      'set endDelay 123.45':
           'anim.effect.getComputedTiming is not a function',
 
       'set endDelay Infinity':
@@ -266,26 +237,29 @@ module.exports = {
 
       'set endDelay negative Infinity':
           'assert_throws: we can not assign negative Infinity to timing.endDelay function "function () {\n"use strict";\n\n    anim.effect.timing.endDe..." did not throw',
-
-      'onfinish event is fired currentTime is after endTime':
-          'FLAKY_TEST_RESULT',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/fill.html': {
-      'set fill none':
-          'anim.effect.getComputedTiming is not a function',
-
-      'set fill forwards':
-          'anim.effect.getComputedTiming is not a function',
-
       'set fill backwards':
           'anim.effect.getComputedTiming is not a function',
 
       'set fill both':
           'anim.effect.getComputedTiming is not a function',
+
+      'set fill forwards':
+          'anim.effect.getComputedTiming is not a function',
+
+      'set fill none':
+          'anim.effect.getComputedTiming is not a function',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/getAnimations.html': {
+      'when currentTime changed in duration:1000, delay: -500, endDelay: -500':
+          'assert_equals: when currentTime 0 expected 0 but got 1',
+
+      'when currentTime changed in duration:1000, delay: 500, endDelay: -500':
+          'assert_equals: set currentTime 1000 expected 0 but got 1',
+
       'when duration is changed':
           'assert_equals: set duration 102000 expected (object) object "[object Object]" but got (undefined) undefined',
 
@@ -294,40 +268,34 @@ module.exports = {
 
       'when iterations is changed':
           'assert_equals: set iterations 10 expected (object) object "[object Object]" but got (undefined) undefined',
-
-      'when currentTime changed in duration:1000, delay: 500, endDelay: -500':
-          'assert_equals: set currentTime 1000 expected 0 but got 1',
-
-      'when currentTime changed in duration:1000, delay: -500, endDelay: -500':
-          'assert_equals: when currentTime 0 expected 0 but got 1',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/getComputedStyle.html': {
+      'change currentTime when fill forwards and endDelay is negative':
+          'assert_equals: set currentTime same as endTime expected "0" but got "0.5"',
+
+      'change currentTime when fill forwards and endDelay is positive':
+          'assert_equals: set currentTime just a little before duration expected "0.0001" but got "0"',
+
       'changed duration immediately updates its computed styles':
           'FLAKY_TEST_RESULT',
 
       'changed iterations immediately updates its computed styles':
           'FLAKY_TEST_RESULT',
-
-      'change currentTime when fill forwards and endDelay is positive':
-          'assert_equals: set currentTime just a little before duration expected "0.0001" but got "0"',
-
-      'change currentTime when fill forwards and endDelay is negative':
-          'assert_equals: set currentTime same as endTime expected "0" but got "0.5"',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/iterationStart.html': {
-      'Test that changing the iterationStart affects computed timing when backwards-filling':
-          'anim.effect.getComputedTiming is not a function',
+      'Test invalid iterationStart value':
+          'assert_throws: function "function () {\n"use strict";\n\n                  anim.effec..." threw object "ReferenceError: timing is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Test that changing the iterationStart affects computed timing during the active phase':
           'anim.effect.getComputedTiming is not a function',
 
-      'Test that changing the iterationStart affects computed timing when forwards-filling':
+      'Test that changing the iterationStart affects computed timing when backwards-filling':
           'anim.effect.getComputedTiming is not a function',
 
-      'Test invalid iterationStart value':
-          'assert_throws: function "function () {\n"use strict";\n\n                  anim.effec..." did not throw',
+      'Test that changing the iterationStart affects computed timing when forwards-filling':
+          'anim.effect.getComputedTiming is not a function',
     },
 
     'test/web-platform-tests/web-animations/animation-effect-timing/iterations.html': {
@@ -336,15 +304,6 @@ module.exports = {
 
       'set iterations Infinity':
           'anim.effect.getComputedTiming is not a function',
-
-      'set negative iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.itera..." did not throw',
-
-      'set negative infinity iterations ':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.itera..." did not throw',
-
-      'set NaN iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.itera..." did not throw',
     },
 
     'test/web-platform-tests/web-animations/animation-model/animation-types/discrete-animation.html': {
@@ -356,35 +315,41 @@ module.exports = {
     },
 
     'test/web-platform-tests/web-animations/animation-model/animation-types/not-animatable.html': {
-      '\'display\' property cannot be animated using property-indexed notation':
-          'assert_equals: Animation specified using property-indexed notation but consisting of only non-animatable properties should not contain any keyframes expected 0 but got 2',
-
       '\'display\' property cannot be animated using a keyframe sequence':
           'assert_false: Initial keyframe should not have the \'display\' property expected false got true',
 
-      'CSS animations and CSS transitions properties cannot be animated using property-indexed notation':
-          'assert_equals: Animation specified using property-indexed notation but consisting of only non-animatable properties should not contain any keyframes expected 0 but got 26',
+      '\'display\' property cannot be animated using property-indexed notation':
+          'assert_equals: Animation specified using property-indexed notation but consisting of only non-animatable properties should not contain any keyframes expected 0 but got 2',
 
       'CSS animations and CSS transitions properties cannot be animated using a sequence of keyframes':
           'assert_array_equals: Initial keyframe should not contain any properties other than the default keyframe properties lengths differ, expected 3 got 14',
+
+      'CSS animations and CSS transitions properties cannot be animated using property-indexed notation':
+          'assert_equals: Animation specified using property-indexed notation but consisting of only non-animatable properties should not contain any keyframes expected 0 but got 26',
     },
 
     'test/web-platform-tests/web-animations/animation-timeline/document-timeline.html': {
-      'document.timeline.currentTime value tests':
-          'assert_true: document.timeline.currentTime is positive expected true got false',
-
       'document.timeline.currentTime liveness tests':
           'assert_true: document.timeline.currentTime increases between script blocks expected true got false',
+
+      'document.timeline.currentTime value tests':
+          'assert_true: document.timeline.currentTime is positive expected true got false',
     },
 
     'test/web-platform-tests/web-animations/animation-timeline/idlharness.html': {
-      'AnimationTimeline interface: existence and properties of interface object':
-          'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
-
       'AnimationTimeline interface object length':
           'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
 
       'AnimationTimeline interface object name':
+          'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
+
+      'AnimationTimeline interface: attribute currentTime':
+          'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
+
+      'AnimationTimeline interface: document.timeline must inherit property "currentTime" with the proper type (0)':
+          'assert_inherits: property "currentTime" found on object expected in prototype chain',
+
+      'AnimationTimeline interface: existence and properties of interface object':
           'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
 
       'AnimationTimeline interface: existence and properties of interface prototype object':
@@ -393,16 +358,13 @@ module.exports = {
       'AnimationTimeline interface: existence and properties of interface prototype object\'s "constructor" property':
           'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
 
-      'AnimationTimeline interface: attribute currentTime':
-          'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
-
-      'DocumentTimeline interface: existence and properties of interface object':
-          'assert_own_property: self does not have own property "DocumentTimeline" expected property "DocumentTimeline" missing',
-
       'DocumentTimeline interface object length':
           'assert_own_property: self does not have own property "DocumentTimeline" expected property "DocumentTimeline" missing',
 
       'DocumentTimeline interface object name':
+          'assert_own_property: self does not have own property "DocumentTimeline" expected property "DocumentTimeline" missing',
+
+      'DocumentTimeline interface: existence and properties of interface object':
           'assert_own_property: self does not have own property "DocumentTimeline" expected property "DocumentTimeline" missing',
 
       'DocumentTimeline interface: existence and properties of interface prototype object':
@@ -414,66 +376,62 @@ module.exports = {
       'DocumentTimeline must be primary interface of document.timeline':
           'assert_own_property: self does not have own property "DocumentTimeline" expected property "DocumentTimeline" missing',
 
-      // Serialization of objects cannot be feasibly overwritten by the polyfill.
       'Stringification of document.timeline':
           'assert_equals: class string of document.timeline expected "[object DocumentTimeline]" but got "[object Object]"',
-
-      'AnimationTimeline interface: document.timeline must inherit property "currentTime" with the proper type (0)':
-          'assert_inherits: property "currentTime" found on object expected in prototype chain',
     },
 
     'test/web-platform-tests/web-animations/animation/cancel.html': {
-      'Animated style is cleared after calling Animation.cancel()':
-          'assert_not_equals: transform style is animated before cancelling got disallowed value "none"',
-
       'After cancelling an animation, it can still be seeked':
           'assert_equals: margin-left style is updated when cancelled animation is seeked expected "50px" but got "0px"',
+
+      'Animated style is cleared after calling Animation.cancel()':
+          'assert_not_equals: transform style is animated before cancelling got disallowed value "none"',
     },
 
     'test/web-platform-tests/web-animations/animation/finish.html': {
-      'Test exceptions when finishing non-running animation':
-          'assert_throws: function "function () {\n"use strict";\n\n    animation.finish();\n  }" did not throw',
-
       'Test exceptions when finishing infinite animation':
           'assert_throws: function "function () {\n"use strict";\n\n    animation.finish();\n  }" did not throw',
 
-      'Test finishing of animation with a current time past the effect end':
-          'animation.effect.getComputedTiming is not a function',
+      'Test exceptions when finishing non-running animation':
+          'assert_throws: function "function () {\n"use strict";\n\n    animation.finish();\n  }" did not throw',
 
-      'Test finish() while paused':
-          'assert_equals: The play state of a paused animation should become "finished" after finish() is called expected "finished" but got "paused"',
-
-      'Test finish() while pause-pending with positive playbackRate':
-          'assert_approx_equals: The start time of a pause-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
+      'Test finish() resolves finished promise synchronously with an animation without a target':
+          'KeyframeEffectReadOnly is not defined',
 
       'Test finish() while pause-pending with negative playbackRate':
           'assert_equals: The start time of a pause-pending animation should be set after calling finish() expected (undefined) undefined but got (number) 100000',
 
+      'Test finish() while pause-pending with positive playbackRate':
+          'assert_approx_equals: The start time of a pause-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
+
+      'Test finish() while paused':
+          'assert_equals: The play state of a paused animation should become "finished" after finish() is called expected "finished" but got "paused"',
+
       'Test finish() while play-pending':
           'assert_approx_equals: The start time of a play-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
 
-      'Test finish() resolves finished promise synchronously with an animation without a target':
-          'KeyframeEffectReadOnly is not defined',
+      'Test finishing of animation with a current time past the effect end':
+          'animation.effect.getComputedTiming is not a function',
 
       'Test normally finished animation resolves finished promise synchronously with an animation without a target':
           'KeyframeEffectReadOnly is not defined',
     },
 
     'test/web-platform-tests/web-animations/animation/finished.html': {
+      'Test finished promise changes for animation duration changes':
+          'assert_equals: currentTime should be unchanged when duration shortened expected 50000 but got 25000',
+
+      'Test finished promise is not resolved once the animation falls out finished state even though the current finished promise is generated soon after animation state became finished':
+          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
+
+      'Test finished promise is not resolved when the animation falls out finished state immediately':
+          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
+
       'cancelling an already-finished animation replaces the finished promise':
           'assert_not_equals: A new finished promise should be created when cancelling a finished animation got disallowed value object "[object Promise]"',
 
       'cancelling an idle animation still replaces the finished promise':
           'assert_not_equals: A redundant call to cancel() should still generate a new finished promise got disallowed value object "[object Promise]"',
-
-      'Test finished promise changes for animation duration changes':
-          'assert_equals: currentTime should be unchanged when duration shortened expected 50000 but got 25000',
-
-      'Test finished promise is not resolved when the animation falls out finished state immediately':
-          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
-
-      'Test finished promise is not resolved once the animation falls out finished state even though the current finished promise is generated soon after animation state became finished':
-          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
     },
 
     'test/web-platform-tests/web-animations/animation/oncancel.html': {
@@ -513,23 +471,23 @@ module.exports = {
     },
 
     'test/web-platform-tests/web-animations/animation/reverse.html': {
-      'reverse() when playbackRate > 0 and currentTime > effect end':
-          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime > effect end expected 100000 but got 200000',
-
-      'reverse() when playbackRate > 0 and currentTime < 0':
-          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime < 0 expected 100000 but got -200000',
-
       'reverse() when playbackRate < 0 and currentTime < 0':
           'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime < 0 expected 0 but got -200000',
+
+      'reverse() when playbackRate < 0 and currentTime < 0 and the target effect end is positive infinity':
+          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime < 0 and the target effect is positive infinity expected 0 but got -200000',
 
       'reverse() when playbackRate < 0 and currentTime > effect end':
           'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime > effect end expected 0 but got 200000',
 
+      'reverse() when playbackRate > 0 and currentTime < 0':
+          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime < 0 expected 100000 but got -200000',
+
       'reverse() when playbackRate > 0 and currentTime < 0 and the target effect end is positive infinity':
           'assert_throws: reverse() should throw InvalidStateError if the playbackRate > 0 and the currentTime < 0 and the target effect is positive infinity function "function () {\n"use strict";\n animation.reverse(); }" did not throw',
 
-      'reverse() when playbackRate < 0 and currentTime < 0 and the target effect end is positive infinity':
-          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime < 0 and the target effect is positive infinity expected 0 but got -200000',
+      'reverse() when playbackRate > 0 and currentTime > effect end':
+          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime > effect end expected 100000 but got 200000',
     },
 
     'test/web-platform-tests/web-animations/document/getAnimations.html': {
@@ -539,24 +497,336 @@ module.exports = {
       'Test document.getAnimations for script-generated animations':
           'document.getAnimations is not a function',
 
-      'Test the order of document.getAnimations with script generated animations':
-          'document.getAnimations is not a function',
-
       'Test document.getAnimations with null target':
           'KeyframeEffectReadOnly is not defined',
+
+      'Test the order of document.getAnimations with script generated animations':
+          'document.getAnimations is not a function',
     },
 
     'test/web-platform-tests/web-animations/keyframe-effect/constructor.html': {
+      'Invalid KeyframeEffectReadOnly option by -Infinity':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by NaN':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a NaN duration':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a NaN iterations':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a blank easing':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a multi-value easing':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a negative Infinity duration':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a negative Infinity iterations':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a negative duration':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a negative iterations':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a negative value':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a string duration':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by a variable easing':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by an \'inherit\' easing':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by an \'initial\' easing':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid KeyframeEffectReadOnly option by an unrecognized easing':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'Invalid easing [a blank easing] in keyframe sequence should be thrown':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+
+      'Invalid easing [a multi-value easing] in keyframe sequence should be thrown':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+
+      'Invalid easing [a variable easing] in keyframe sequence should be thrown':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+
+      'Invalid easing [an \'inherit\' easing] in keyframe sequence should be thrown':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+
+      'Invalid easing [an \'initial\' easing] in keyframe sequence should be thrown':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+
+      'Invalid easing [an unrecognized easing] in keyframe sequence should be thrown':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+
+      'KeyframeEffect constructor creates an AnimationEffectTiming timing object':
+          'assert_equals: expected "[object KeyframeEffect]" but got "[object Object]"',
+
+      'KeyframeEffectReadOnly constructor throws with a keyframe sequence with an invalid easing value':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'KeyframeEffectReadOnly constructor throws with keyframes not loosely sorted by offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'KeyframeEffectReadOnly constructor throws with keyframes with an invalid composite value':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'KeyframeEffectReadOnly constructor throws with keyframes with an out-of-bounded negative offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'KeyframeEffectReadOnly constructor throws with keyframes with an out-of-bounded positive offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'KeyframeEffectReadOnly constructor throws with property-indexed keyframes with an invalid easing value':
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where greater shorthand precedes lesser shorthand':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where lesser shorthand precedes greater shorthand':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where longhand precedes shorthand':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where shorthand precedes longhand':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with different composite values, but the same composite value for a given offset':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with different easing values, but the same easing value for a given offset':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with duplicate values for a given interior offset':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with duplicate values for offsets 0 and 1':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property keyframe sequence with all omitted offsets':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property keyframe sequence with some omitted offsets':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property one keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property one non-array value property-indexed keyframes specification':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property one value property-indexed keyframes specification':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property two keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property two keyframe sequence that needs to stringify its values':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification that needs to stringify its values':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification where the first value is invalid':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification where the second value is invalid':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one shorthand property two keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a one shorthand property two value property-indexed keyframes specification':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with an invalid value':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with repeated values at offset 0 with different easings':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a single keyframe sequence with omitted offsets':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property four keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property keyframe sequence with some omitted offsets':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification where one property is missing from the first keyframe':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification where one property is missing from the last keyframe':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification with different numbers of values':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property two keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property two value property-indexed keyframes specification':
+          'KeyframeEffectReadOnly is not defined',
+
       'a KeyframeEffectReadOnly can be constructed with no frames':
           'KeyframeEffectReadOnly is not defined',
 
-      'easing values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in a property-indexed keyframe':
+      'a KeyframeEffectReadOnly constructed by +Infinity':
           'KeyframeEffectReadOnly is not defined',
 
-      'easing values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in regular keyframes':
+      'a KeyframeEffectReadOnly constructed by a double value':
           'KeyframeEffectReadOnly is not defined',
 
-      'easing values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in KeyframeTimingOptions':
+      'a KeyframeEffectReadOnly constructed by a forwards fill':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed by a normal KeyframeEffectOptions object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed by an Infinity duration':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed by an Infinity iterations':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed by an auto duration':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed by an auto fill':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed by an empty KeyframeEffectOptions object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence where greater shorthand precedes lesser shorthand roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence where lesser shorthand precedes greater shorthand roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence where longhand precedes shorthand roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence where shorthand precedes longhand roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence with different composite values, but the same composite value for a given offset roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence with different easing values, but the same easing value for a given offset roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence with duplicate values for a given interior offset roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence with duplicate values for offsets 0 and 1 roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property keyframe sequence with all omitted offsets roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property keyframe sequence with some omitted offsets roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property one keyframe sequence roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property one non-array value property-indexed keyframes specification roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property one value property-indexed keyframes specification roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property two keyframe sequence roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property two keyframe sequence that needs to stringify its values roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification that needs to stringify its values roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification where the first value is invalid roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification where the second value is invalid roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one shorthand property two keyframe sequence roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a one shorthand property two value property-indexed keyframes specification roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with an invalid value roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with repeated values at offset 0 with different easings roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a single keyframe sequence with omitted offsets roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property four keyframe sequence roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property keyframe sequence with some omitted offsets roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification where one property is missing from the first keyframe roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification where one property is missing from the last keyframe roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification with different numbers of values roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property two keyframe sequence roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property two value property-indexed keyframes specification roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with null target':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed without any KeyframeEffectOptions object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'composite values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in KeyframeTimingOptions':
           'KeyframeEffectReadOnly is not defined',
 
       'composite values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in property-indexed keyframes':
@@ -565,379 +835,27 @@ module.exports = {
       'composite values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in regular keyframes':
           'KeyframeEffectReadOnly is not defined',
 
-      'composite values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in KeyframeTimingOptions':
+      'easing values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in KeyframeTimingOptions':
           'KeyframeEffectReadOnly is not defined',
 
-      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification':
+      'easing values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in a property-indexed keyframe':
           'KeyframeEffectReadOnly is not defined',
 
-      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one shorthand property two value property-indexed keyframes specification':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one shorthand property two value property-indexed keyframes specification roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property two value property-indexed keyframes specification':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property two value property-indexed keyframes specification roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification with different numbers of values':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification with different numbers of values roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with an invalid value':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with an invalid value roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification that needs to stringify its values':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification that needs to stringify its values roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property one value property-indexed keyframes specification':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property one value property-indexed keyframes specification roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property one non-array value property-indexed keyframes specification':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property one non-array value property-indexed keyframes specification roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification where the first value is invalid':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification where the first value is invalid roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property two value property-indexed keyframes specification where the second value is invalid':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property two value property-indexed keyframes specification where the second value is invalid roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification where one property is missing from the first keyframe':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification where one property is missing from the first keyframe roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification where one property is missing from the last keyframe':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification where one property is missing from the last keyframe roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with repeated values at offset 0 with different easings':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with repeated values at offset 0 with different easings roundtrips':
+      'easing values are parsed correctly when passed to the KeyframeEffectReadOnly constructor in regular keyframes':
           'KeyframeEffectReadOnly is not defined',
 
       'the KeyframeEffectReadOnly constructor reads keyframe properties in the expected order':
           'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property one keyframe sequence':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property one keyframe sequence roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property two keyframe sequence':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property two keyframe sequence roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property two keyframe sequence':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property two keyframe sequence roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one shorthand property two keyframe sequence':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one shorthand property two keyframe sequence roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property (a shorthand and one of its component longhands) two keyframe sequence roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with duplicate values for a given interior offset':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence with duplicate values for a given interior offset roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with duplicate values for offsets 0 and 1':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence with duplicate values for offsets 0 and 1 roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property four keyframe sequence':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property four keyframe sequence roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a single keyframe sequence with omitted offsets':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a single keyframe sequence with omitted offsets roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property keyframe sequence with some omitted offsets':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property keyframe sequence with some omitted offsets roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property keyframe sequence with some omitted offsets':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property keyframe sequence with some omitted offsets roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property keyframe sequence with all omitted offsets':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property keyframe sequence with all omitted offsets roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with different easing values, but the same easing value for a given offset':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence with different easing values, but the same easing value for a given offset roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with different composite values, but the same composite value for a given offset':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence with different composite values, but the same composite value for a given offset roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a one property two keyframe sequence that needs to stringify its values':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a one property two keyframe sequence that needs to stringify its values roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where shorthand precedes longhand':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence where shorthand precedes longhand roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where longhand precedes shorthand':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence where longhand precedes shorthand roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where lesser shorthand precedes greater shorthand':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence where lesser shorthand precedes greater shorthand roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where greater shorthand precedes lesser shorthand':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a keyframe sequence where greater shorthand precedes lesser shorthand roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'KeyframeEffectReadOnly constructor throws with keyframes with an out-of-bounded positive offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'KeyframeEffectReadOnly constructor throws with keyframes with an out-of-bounded negative offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'KeyframeEffectReadOnly constructor throws with keyframes not loosely sorted by offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'KeyframeEffectReadOnly constructor throws with property-indexed keyframes with an invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'KeyframeEffectReadOnly constructor throws with a keyframe sequence with an invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'KeyframeEffectReadOnly constructor throws with keyframes with an invalid composite value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid easing [a blank easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
-
-      'Invalid easing [an unrecognized easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
-
-      'Invalid easing [an \'initial\' easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
-
-      'Invalid easing [an \'inherit\' easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
-
-      'Invalid easing [a variable easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
-
-      'Invalid easing [a multi-value easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
-
-      'a KeyframeEffectReadOnly constructed without any KeyframeEffectOptions object':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by an empty KeyframeEffectOptions object':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by a normal KeyframeEffectOptions object':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by a double value':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by +Infinity':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by an Infinity duration':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by an auto duration':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by an Infinity iterations':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by an auto fill':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed by a forwards fill':
-          'KeyframeEffectReadOnly is not defined',
-
-      'Invalid KeyframeEffectReadOnly option by -Infinity':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by NaN':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a negative value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a negative Infinity duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a NaN duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a negative duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a string duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a negative Infinity iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a NaN iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a negative iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a blank easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by an unrecognized easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by an \'initial\' easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by an \'inherit\' easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a variable easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'Invalid KeyframeEffectReadOnly option by a multi-value easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
-
-      'a KeyframeEffectReadOnly constructed with null target':
-          'KeyframeEffectReadOnly is not defined',
-
-      // Serialization of objects cannot be feasibly overwritten by the polyfill.
-      'KeyframeEffect constructor creates an AnimationEffectTiming timing object':
-          'assert_equals: expected "[object KeyframeEffect]" but got "[object Object]"',
     },
 
     'test/web-platform-tests/web-animations/keyframe-effect/getComputedTiming.html': {
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed without any KeyframeEffectOptions object':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an empty KeyframeEffectOptions object':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by a normal KeyframeEffectOptions object':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by a double value':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by +Infinity':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an Infinity duration':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an auto duration':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an Infinity iterations':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an auto fill':
-          'KeyframeEffectReadOnly is not defined',
-
-      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by a forwards fill':
-          'KeyframeEffectReadOnly is not defined',
-
-      'getComputedTiming().activeDuration for an empty KeyframeEffectOptions object':
-          'KeyframeEffectReadOnly is not defined',
-
       'getComputedTiming().activeDuration for a non-zero duration and default iteration count':
-          'KeyframeEffectReadOnly is not defined',
-
-      'getComputedTiming().activeDuration for a non-zero duration and integral iteration count':
           'KeyframeEffectReadOnly is not defined',
 
       'getComputedTiming().activeDuration for a non-zero duration and fractional iteration count':
           'KeyframeEffectReadOnly is not defined',
 
-      'getComputedTiming().activeDuration for an non-zero duration and infinite iteration count':
-          'KeyframeEffectReadOnly is not defined',
-
-      'getComputedTiming().activeDuration for an non-zero duration and zero iteration count':
+      'getComputedTiming().activeDuration for a non-zero duration and integral iteration count':
           'KeyframeEffectReadOnly is not defined',
 
       'getComputedTiming().activeDuration for a zero duration and default iteration count':
@@ -952,10 +870,10 @@ module.exports = {
       'getComputedTiming().activeDuration for a zero duration and zero iteration count':
           'KeyframeEffectReadOnly is not defined',
 
-      'getComputedTiming().activeDuration for an infinite duration and default iteration count':
+      'getComputedTiming().activeDuration for an empty KeyframeEffectOptions object':
           'KeyframeEffectReadOnly is not defined',
 
-      'getComputedTiming().activeDuration for an infinite duration and zero iteration count':
+      'getComputedTiming().activeDuration for an infinite duration and default iteration count':
           'KeyframeEffectReadOnly is not defined',
 
       'getComputedTiming().activeDuration for an infinite duration and fractional iteration count':
@@ -964,7 +882,13 @@ module.exports = {
       'getComputedTiming().activeDuration for an infinite duration and infinite iteration count':
           'KeyframeEffectReadOnly is not defined',
 
-      'getComputedTiming().endTime for an empty KeyframeEffectOptions object':
+      'getComputedTiming().activeDuration for an infinite duration and zero iteration count':
+          'KeyframeEffectReadOnly is not defined',
+
+      'getComputedTiming().activeDuration for an non-zero duration and infinite iteration count':
+          'KeyframeEffectReadOnly is not defined',
+
+      'getComputedTiming().activeDuration for an non-zero duration and zero iteration count':
           'KeyframeEffectReadOnly is not defined',
 
       'getComputedTiming().endTime for a non-zero duration and default iteration count':
@@ -979,7 +903,10 @@ module.exports = {
       'getComputedTiming().endTime for a non-zero duration, non-zero delay and non-default iteration':
           'KeyframeEffectReadOnly is not defined',
 
-      'getComputedTiming().endTime for an infinite iteration count':
+      'getComputedTiming().endTime for a zero duration and negative delay':
+          'KeyframeEffectReadOnly is not defined',
+
+      'getComputedTiming().endTime for an empty KeyframeEffectOptions object':
           'KeyframeEffectReadOnly is not defined',
 
       'getComputedTiming().endTime for an infinite duration':
@@ -991,13 +918,43 @@ module.exports = {
       'getComputedTiming().endTime for an infinite duration and negative delay':
           'KeyframeEffectReadOnly is not defined',
 
+      'getComputedTiming().endTime for an infinite iteration count':
+          'KeyframeEffectReadOnly is not defined',
+
       'getComputedTiming().endTime for an non-zero duration and negative delay':
           'KeyframeEffectReadOnly is not defined',
 
       'getComputedTiming().endTime for an non-zero duration and negative delay greater than active duration':
           'KeyframeEffectReadOnly is not defined',
 
-      'getComputedTiming().endTime for a zero duration and negative delay':
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by +Infinity':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by a double value':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by a forwards fill':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by a normal KeyframeEffectOptions object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an Infinity duration':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an Infinity iterations':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an auto duration':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an auto fill':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed by an empty KeyframeEffectOptions object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'values of getComputedTiming() when a KeyframeEffectReadOnly is constructed without any KeyframeEffectOptions object':
           'KeyframeEffectReadOnly is not defined',
     },
 
@@ -1007,64 +964,22 @@ module.exports = {
     },
 
     'test/web-platform-tests/web-animations/keyframe-effect/setFrames.html': {
-      'Keyframes can be replaced with an empty keyframe':
+      'Keyframes can be replaced with a keyframe sequence where greater shorthand precedes lesser shorthand':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a one property two value property-indexed keyframes specification':
+      'Keyframes can be replaced with a keyframe sequence where lesser shorthand precedes greater shorthand':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a one shorthand property two value property-indexed keyframes specification':
+      'Keyframes can be replaced with a keyframe sequence where longhand precedes shorthand':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
+      'Keyframes can be replaced with a keyframe sequence where shorthand precedes longhand':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a two property two value property-indexed keyframes specification':
+      'Keyframes can be replaced with a keyframe sequence with different composite values, but the same composite value for a given offset':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a two property property-indexed keyframes specification with different numbers of values':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a property-indexed keyframes specification with an invalid value':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one property two value property-indexed keyframes specification that needs to stringify its values':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one property one value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one property one non-array value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one property two value property-indexed keyframes specification where the first value is invalid':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one property two value property-indexed keyframes specification where the second value is invalid':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a two property property-indexed keyframes specification where one property is missing from the first keyframe':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a two property property-indexed keyframes specification where one property is missing from the last keyframe':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a property-indexed keyframes specification with repeated values at offset 0 with different easings':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one property one keyframe sequence':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one property two keyframe sequence':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a two property two keyframe sequence':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a one shorthand property two keyframe sequence':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a two property (a shorthand and one of its component longhands) two keyframe sequence':
+      'Keyframes can be replaced with a keyframe sequence with different easing values, but the same easing value for a given offset':
           'effect.setFrames is not a function',
 
       'Keyframes can be replaced with a keyframe sequence with duplicate values for a given interior offset':
@@ -1073,52 +988,94 @@ module.exports = {
       'Keyframes can be replaced with a keyframe sequence with duplicate values for offsets 0 and 1':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a two property four keyframe sequence':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a single keyframe sequence with omitted offsets':
+      'Keyframes can be replaced with a one property keyframe sequence with all omitted offsets':
           'effect.setFrames is not a function',
 
       'Keyframes can be replaced with a one property keyframe sequence with some omitted offsets':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a two property keyframe sequence with some omitted offsets':
+      'Keyframes can be replaced with a one property one keyframe sequence':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a one property keyframe sequence with all omitted offsets':
+      'Keyframes can be replaced with a one property one non-array value property-indexed keyframes specification':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a keyframe sequence with different easing values, but the same easing value for a given offset':
+      'Keyframes can be replaced with a one property one value property-indexed keyframes specification':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a keyframe sequence with different composite values, but the same composite value for a given offset':
+      'Keyframes can be replaced with a one property two keyframe sequence':
           'effect.setFrames is not a function',
 
       'Keyframes can be replaced with a one property two keyframe sequence that needs to stringify its values':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a keyframe sequence where shorthand precedes longhand':
+      'Keyframes can be replaced with a one property two value property-indexed keyframes specification':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a keyframe sequence where longhand precedes shorthand':
+      'Keyframes can be replaced with a one property two value property-indexed keyframes specification that needs to stringify its values':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a keyframe sequence where lesser shorthand precedes greater shorthand':
+      'Keyframes can be replaced with a one property two value property-indexed keyframes specification where the first value is invalid':
           'effect.setFrames is not a function',
 
-      'Keyframes can be replaced with a keyframe sequence where greater shorthand precedes lesser shorthand':
+      'Keyframes can be replaced with a one property two value property-indexed keyframes specification where the second value is invalid':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a one shorthand property two keyframe sequence':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a one shorthand property two value property-indexed keyframes specification':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a property-indexed keyframes specification with an invalid value':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a property-indexed keyframes specification with repeated values at offset 0 with different easings':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a single keyframe sequence with omitted offsets':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property (a shorthand and one of its component longhands) two keyframe sequence':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property four keyframe sequence':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property keyframe sequence with some omitted offsets':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property property-indexed keyframes specification where one property is missing from the first keyframe':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property property-indexed keyframes specification where one property is missing from the last keyframe':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property property-indexed keyframes specification with different numbers of values':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property two keyframe sequence':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with a two property two value property-indexed keyframes specification':
+          'effect.setFrames is not a function',
+
+      'Keyframes can be replaced with an empty keyframe':
           'effect.setFrames is not a function',
     },
 
     'test/web-platform-tests/web-animations/keyframe-effect/setTarget.html': {
-      'Test setting target from null to a valid target':
-          'assert_equals: Value at 50% progress after setting new target expected "50px" but got "10px"',
+      'Test setting target from a valid target to another target':
+          'assert_equals: Value of 1st element (currently not targeted) after changing the effect target expected "10px" but got "50px"',
 
       'Test setting target from a valid target to null':
           'assert_equals: Value after clearing the target expected "10px" but got "50px"',
 
-      'Test setting target from a valid target to another target':
-          'assert_equals: Value of 1st element (currently not targeted) after changing the effect target expected "10px" but got "50px"',
+      'Test setting target from null to a valid target':
+          'assert_equals: Value at 50% progress after setting new target expected "50px" but got "10px"',
     },
 
     'test/web-platform-tests/web-animations/timing-model/animation-effects/active-time.html': {
@@ -1130,60 +1087,6 @@ module.exports = {
       'Test currentIteration during before and after phase when fill is none':
           'anim.effect.getComputedTiming is not a function',
 
-      'Test zero iterations: iterations:0 iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
       'Test fractional iterations: iterations:3.5 iterationStart:0 duration:0 delay:1 fill:both':
           'anim.effect.getComputedTiming is not a function',
 
@@ -1236,64 +1139,64 @@ module.exports = {
           'anim.effect.getComputedTiming is not a function',
 
       'Test infinity iterations: iterations:Infinity iterationStart:3 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:0 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:0 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:0 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:2.5 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:2.5 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:2.5 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:3 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:3 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:3 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:0 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:0 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:0 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:2.5 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:2.5 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:2.5 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:3 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:3 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:3 duration:Infinity delay:1 fill:both':
           'anim.effect.getComputedTiming is not a function',
     },
 
     'test/web-platform-tests/web-animations/timing-model/animation-effects/simple-iteration-progress.html': {
-      'Test zero iterations: iterations:0 iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test zero iterations: iterations:0 iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
       'Test fractional iterations: iterations:3.5 iterationStart:0 duration:0 delay:1 fill:both':
           'anim.effect.getComputedTiming is not a function',
 
@@ -1347,20 +1250,74 @@ module.exports = {
 
       'Test infinity iterations: iterations:Infinity iterationStart:3 duration:Infinity delay:1 fill:both':
           'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:0 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:0 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:0 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:2.5 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:2.5 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:2.5 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:3 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:3 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test integer iterations: iterations:3 iterationStart:3 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:0 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:0 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:0 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:2.5 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:2.5 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:2.5 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:3 duration:0 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:3 duration:100 delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
+
+      'Test zero iterations: iterations:0 iterationStart:3 duration:Infinity delay:1 fill:both':
+          'anim.effect.getComputedTiming is not a function',
     },
 
     'test/web-platform-tests/web-animations/timing-model/animations/set-the-animation-start-time.html': {
-      'Setting the start time of an animation without an active timeline':
-          'Animation with null timeline is not supported',
-
       'Setting an unresolved start time an animation without an active timeline does not clear the current time':
           'Animation with null timeline is not supported',
+
+      'Setting an unresolved start time sets the hold time':
+          'assert_equals: expected "running" but got "idle"',
 
       'Setting the start time clears the hold time':
           'assert_equals: The current time is calculated from the hold time expected (number) 1000 but got (object) null',
 
-      'Setting an unresolved start time sets the hold time':
-          'assert_equals: expected "running" but got "idle"',
+      'Setting the start time of an animation without an active timeline':
+          'Animation with null timeline is not supported',
 
       'Setting the start time resolves a pending pause task':
           'assert_equals: Animation is in pause-pending state expected "pending" but got "idle"',

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -1,54 +1,85 @@
 // Expectations to be used by karma-testharness-adapter.js.
 module.exports = {
   skip: {
-    'test/web-platform-tests/web-animations/animation/constructor.html':
+    'test/web-platform-tests/web-animations/interfaces/Animation/constructor.html':
         'KeyframeEffectReadOnly is not defined causing the test to timeout.',
 
-    'test/web-platform-tests/web-animations/keyframe-effect/effect-easing.html':
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/effect-easing.html':
+        'It seems to enter an infinite loop and halt the browser.',
+
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/effect-easing-steps.html':
         'It seems to enter an infinite loop and halt the browser.',
   },
 
   flakyTestIndicator: 'FLAKY_TEST_RESULT',
   expectedFailures: {
-    'test/web-platform-tests/web-animations/animatable/animate.html': {
-      'CSSPseudoElement.animate() creates an Animation object':
-          'document.getAnimations is not a function',
+    'test/web-platform-tests/web-animations/animation-model/keyframe-effects/the-effect-value-of-a-keyframe-effect.html': {
+      'Overlapping keyframes at 0 and 1 use the appropriate value when the progress is outside the range [0, 1]':
+          'assert_equals: When progress is negative, the first keyframe with a 0 offset should be used expected "0" but got "0.151"',
+    },
 
-      'CSSPseudoElement.animate() creates an Animation object targeting to the correct CSSPseudoElement object':
-          'document.getAnimations is not a function',
+    'test/web-platform-tests/web-animations/interfaces/Animatable/animate-basic.html': {
+      'Element.animate() creates an Animation object':
+          'assert_equals: Returned object is an Animation expected "[object Animation]" but got "[object Object]"',
 
+      'Element.animate() does not accept keyframes not loosely sorted by offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.input, 2000);\n    }" threw object "[object Object]" ("InvalidModificationError") expected object "[object Object]" ("TypeError")',
+
+      'Element.animate() does not accept keyframes with an invalid composite value':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.input, 2000);\n    }" threw object "[object Object]" ("NotSupportedError") expected object "[object Object]" ("TypeError")',
+
+      'Element.animate() does not accept keyframes with an out-of-bounded negative offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.input, 2000);\n    }" did not throw',
+
+      'Element.animate() does not accept keyframes with an out-of-bounded positive offset':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.input, 2000);\n    }" did not throw',
+
+      'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
+          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.input, 2000);\n    }" did not throw',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animatable/animate-effect.html': {
       'Element.animate() accepts a double as an options argument':
           'assert_equals: expected "auto" but got "none"',
 
       'Element.animate() accepts a keyframe sequence where greater shorthand precedes lesser shorthand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "border,borderLeft,computedOffset,easing,offset" but got "borderBottomColor,borderBottomStyle,borderBottomWidth,borderLeftColor,borderLeftStyle,borderLeftWidth,borderRightColor,borderRightStyle,borderRightWidth,borderTopColor,borderTopStyle,borderTopWidth,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a keyframe sequence where lesser shorthand precedes greater shorthand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "border,borderLeft,computedOffset,easing,offset" but got "borderBottomColor,borderBottomStyle,borderBottomWidth,borderLeftColor,borderLeftStyle,borderLeftWidth,borderRightColor,borderRightStyle,borderRightWidth,borderTopColor,borderTopStyle,borderTopWidth,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a keyframe sequence where longhand precedes shorthand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginRight,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a keyframe sequence where shorthand precedes longhand':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginRight,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+          'anim.effect.getKeyframes is not a function',
+
+      'Element.animate() accepts a keyframe sequence with a CSS variable reference':
+          'anim.effect.getKeyframes is not a function',
+
+      'Element.animate() accepts a keyframe sequence with a CSS variable reference in a shorthand property':
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a keyframe sequence with different composite values, but the same composite value for a given offset':
           'add compositing is not supported',
 
       'Element.animate() accepts a keyframe sequence with different easing values, but the same easing value for a given offset':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "easing,left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a keyframe sequence with duplicate values for a given interior offset':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a keyframe sequence with duplicate values for offsets 0 and 1':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
+
+      'Element.animate() accepts a keyframe sequence with repeated values at offset 1 with different easings':
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property keyframe sequence with all omitted offsets':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property keyframe sequence with some omitted offsets':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property one keyframe sequence':
           'Partial keyframes are not supported',
@@ -60,94 +91,199 @@ module.exports = {
           'Partial keyframes are not supported',
 
       'Element.animate() accepts a one property two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property two keyframe sequence that needs to stringify its values':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,offset,opacity" but got "offset,opacity"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property two value property-indexed keyframes specification':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property two value property-indexed keyframes specification that needs to stringify its values':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,offset,opacity" but got "offset,opacity"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property two value property-indexed keyframes specification where the first value is invalid':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one property two value property-indexed keyframes specification where the second value is invalid':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one shorthand property two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a one shorthand property two value property-indexed keyframes specification':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+          'anim.effect.getKeyframes is not a function',
+
+      'Element.animate() accepts a property-indexed keyframes specification with a CSS variable reference':
+          'anim.effect.getKeyframes is not a function',
+
+      'Element.animate() accepts a property-indexed keyframes specification with a CSS variable reference in a shorthand property':
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a property-indexed keyframes specification with an invalid value':
-          'assert_equals: number of frames expected 5 but got 10',
-
-      'Element.animate() accepts a property-indexed keyframes specification with repeated values at offset 0 with different easings':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "easing,left,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a single keyframe sequence with omitted offsets':
           'Partial keyframes are not supported',
 
       'Element.animate() accepts a two property (a shorthand and one of its component longhands) two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,margin,marginTop,offset" but got "marginBottom,marginLeft,marginRight,marginTop,offset"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
-          'assert_equals: number of frames expected 2 but got 4',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a two property four keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset" but got "left,offset"',
+          'anim.effect.getKeyframes is not a function',
+
+      'Element.animate() accepts a two property keyframe sequence where one property is missing from the first keyframe':
+          'Partial keyframes are not supported',
+
+      'Element.animate() accepts a two property keyframe sequence where one property is missing from the last keyframe':
+          'Partial keyframes are not supported',
 
       'Element.animate() accepts a two property keyframe sequence with some omitted offsets':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset,top" but got "left,offset,top"',
-
-      'Element.animate() accepts a two property property-indexed keyframes specification where one property is missing from the first keyframe':
-          'Partial keyframes are not supported',
-
-      'Element.animate() accepts a two property property-indexed keyframes specification where one property is missing from the last keyframe':
-          'Partial keyframes are not supported',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a two property property-indexed keyframes specification with different numbers of values':
-          'assert_equals: number of frames expected 3 but got 5',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a two property two keyframe sequence':
-          'assert_equals: properties on ComputedKeyframe #0 expected "computedOffset,easing,left,offset,top" but got "left,offset,top"',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts a two property two value property-indexed keyframes specification':
-          'assert_equals: number of frames expected 2 but got 4',
+          'anim.effect.getKeyframes is not a function',
 
       'Element.animate() accepts an absent options argument':
           'assert_equals: expected (string) "auto" but got (number) 0',
 
-      'Element.animate() correctly sets the Animation\'s timeline when triggered on an element in a different document':
-          'div.animate is not a function',
-
-      'Element.animate() creates an Animation object':
-          'assert_equals: Returned object is an Animation expected "[object Animation]" but got "[object Object]"',
-
       'Element.animate() creates an Animation object with a KeyframeEffect':
           'assert_equals: Returned Animation has a KeyframeEffect expected "[object KeyframeEffect]" but got "[object Object]"',
-
-      'Element.animate() does not accept keyframes not loosely sorted by offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." threw object "[object Object]" ("InvalidModificationError") expected object "[object Object]" ("TypeError")',
-
-      'Element.animate() does not accept keyframes with an invalid composite value':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." threw object "[object Object]" ("NotSupportedError") expected object "[object Object]" ("TypeError")',
-
-      'Element.animate() does not accept keyframes with an out-of-bounded negative offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
-
-      'Element.animate() does not accept keyframes with an out-of-bounded positive offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
-
-      'Element.animate() does not accept property-indexed keyframes with an invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n      div.animate(subtest.in..." did not throw',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/delay.html': {
+    'test/web-platform-tests/web-animations/interfaces/Animatable/animate-pseudo-element.html': {
+      'CSSPseudoElement.animate() creates an Animation object':
+          'document.getAnimations is not a function',
+
+      'CSSPseudoElement.animate() creates an Animation object targeting to the correct CSSPseudoElement object':
+          'document.getAnimations is not a function',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animatable/animate-timeline.html': {
+      'Element.animate() correctly sets the Animation\'s timeline when triggered on an element in a different document':
+          'div.animate is not a function',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/cancel.html': {
+      'After cancelling an animation, it can still be seeked':
+          'assert_equals: margin-left style is updated when cancelled animation is seeked expected "50px" but got "0px"',
+
+      'Animated style is cleared after calling Animation.cancel()':
+          'assert_not_equals: transform style is animated before cancelling got disallowed value "none"',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/finish.html': {
+      'Test exceptions when finishing infinite animation':
+          'assert_throws: function "function () {\n"use strict";\n\n    animation.finish();\n  }" did not throw',
+
+      'Test exceptions when finishing non-running animation':
+          'assert_throws: function "function () {\n"use strict";\n\n    animation.finish();\n  }" did not throw',
+
+      'Test finish() resolves finished promise synchronously with an animation without a target':
+          'KeyframeEffectReadOnly is not defined',
+
+      'Test finish() while pause-pending with negative playbackRate':
+          'assert_equals: The start time of a pause-pending animation should be set after calling finish() expected (undefined) undefined but got (number) 100000',
+
+      'Test finish() while pause-pending with positive playbackRate':
+          'assert_approx_equals: The start time of a pause-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
+
+      'Test finish() while paused':
+          'assert_equals: The play state of a paused animation should become "finished" after finish() is called expected "finished" but got "paused"',
+
+      'Test finish() while play-pending':
+          'assert_approx_equals: The start time of a play-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
+
+      'Test finishing of animation with a current time past the effect end':
+          'animation.effect.getComputedTiming is not a function',
+
+      'Test normally finished animation resolves finished promise synchronously with an animation without a target':
+          'KeyframeEffectReadOnly is not defined',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/finished.html': {
+      'Test finished promise changes for animation duration changes':
+          'assert_equals: currentTime should be unchanged when duration shortened expected 50000 but got 25000',
+
+      'Test finished promise is not resolved once the animation falls out finished state even though the current finished promise is generated soon after animation state became finished':
+          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
+
+      'Test finished promise is not resolved when the animation falls out finished state immediately':
+          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
+
+      'cancelling an already-finished animation replaces the finished promise':
+          'assert_not_equals: A new finished promise should be created when cancelling a finished animation got disallowed value object "[object Promise]"',
+
+      'cancelling an idle animation still replaces the finished promise':
+          'assert_not_equals: A redundant call to cancel() should still generate a new finished promise got disallowed value object "[object Promise]"',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/oncancel.html': {
+      'oncancel event is fired when animation.cancel() is called.':
+          'assert_equals: event.timelineTime should equal to the animation timeline when finished promise is rejected expected (undefined) undefined but got (number) 1111.6200000000001',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/onfinish.html': {
+      'onfinish event is fired when animation.finish() is called':
+          'assert_equals: event.timelineTime should equal to the animation timeline when finished promise is resolved expected (undefined) undefined but got (number) 1079.882351',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/pause.html': {
+      'pause() from idle':
+          'assert_equals: currentTime is set to 0 expected (number) 0 but got (object) null',
+
+      'pause() from idle with a negative playbackRate':
+          'assert_equals: currentTime is set to the effect end expected (number) 1000000 but got (object) null',
+
+      'pause() from idle with a negative playbackRate and endless effect':
+          'assert_throws: Expect InvalidStateError exception on calling pause() from idle with a negative playbackRate and infinite-duration animation function "function () {\n"use strict";\n animation.pause(); }" did not throw',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/play.html': {
+      'play() throws when seeking an infinite-duration animation played in reverse':
+          'assert_throws: Expected InvalidStateError exception on calling play() with a negative playbackRate and infinite-duration animation function "function () {\n"use strict";\n animation.play(); }" did not throw',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/playState.html': {
+      'Animation.playState is \'paused\' after cancelling an animation, seeking it makes it paused':
+          'assert_equals: After seeking an idle animation, it is effectively paused expected "paused" but got "idle"',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/playbackRate.html': {
+      'Test the effect of setting playbackRate while playing animation':
+          'assert_approx_equals: animation.currentTime should be the same speed as timeline now. expected 16.114772999999786 +/- 0.001 but got 0',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/Animation/reverse.html': {
+      'reverse() when playbackRate < 0 and currentTime < 0':
+          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime < 0 expected 0 but got -200000',
+
+      'reverse() when playbackRate < 0 and currentTime < 0 and the target effect end is positive infinity':
+          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime < 0 and the target effect is positive infinity expected 0 but got -200000',
+
+      'reverse() when playbackRate < 0 and currentTime > effect end':
+          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime > effect end expected 0 but got 200000',
+
+      'reverse() when playbackRate > 0 and currentTime < 0':
+          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime < 0 expected 100000 but got -200000',
+
+      'reverse() when playbackRate > 0 and currentTime < 0 and the target effect end is positive infinity':
+          'assert_throws: reverse() should throw InvalidStateError if the playbackRate > 0 and the currentTime < 0 and the target effect is positive infinity function "function () {\n"use strict";\n animation.reverse(); }" did not throw',
+
+      'reverse() when playbackRate > 0 and currentTime > effect end':
+          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime > effect end expected 100000 but got 200000',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/delay.html': {
       'Test adding a positive delay to an animation without a backwards fill makes it no longer active':
           'anim.effect.getComputedTiming is not a function',
 
@@ -164,18 +300,18 @@ module.exports = {
           'anim.effect.getComputedTiming is not a function',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/duration.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/duration.html': {
       'set 100 string duration in animate using an options object':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
+          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [ 0, 1 ] }, { duration: \'100\' });\n  }" did not throw',
 
       'set NaN duration in animate using a duration parameter':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
+          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [ 0, 1 ] }, NaN);\n  }" did not throw',
 
       'set NaN duration in animate using an options object':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
+          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [ 0, 1 ] }, { duration: NaN });\n  }" did not throw',
 
       'set abc string duration in animate using an options object':
-          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [..." did not throw',
+          'assert_throws: function "function () {\n"use strict";\n\n    div.animate({ opacity: [ 0, 1 ] }, { duration: \'abc\' });\n  }" did not throw',
 
       'set auto duration in animate as object':
           'assert_equals: set duration \'auto\' expected (string) "auto" but got (number) 0',
@@ -190,10 +326,10 @@ module.exports = {
           'anim.effect.getComputedTiming is not a function',
 
       'set duration string 100':
-          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.durat..." did not throw',
+          'assert_throws: function "function () {\n"use strict";\n\n    anim.effect.timing.duration = \'100\';\n  }" did not throw',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/easing.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/easing.html': {
       'Change the easing while the animation is running':
           'anim.effect.getComputedTiming is not a function',
 
@@ -222,9 +358,9 @@ module.exports = {
           'animation.effect.getComputedTiming is not a function',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/endDelay.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/endDelay.html': {
       'onfinish event is fired currentTime is after endTime':
-          'FLAKY_TEST_RESULT',
+          'assert_equals: receivedEvents[0].timelineTime should equal to the animation timeline when finished promise is resolved expected 1173.360423 but got 1190.491128',
 
       'set endDelay -1000':
           'anim.effect.getComputedTiming is not a function',
@@ -233,13 +369,13 @@ module.exports = {
           'anim.effect.getComputedTiming is not a function',
 
       'set endDelay Infinity':
-          'assert_throws: we can not assign Infinity to timing.endDelay function "function () {\n"use strict";\n\n    anim.effect.timing.endDe..." did not throw',
+          'assert_throws: we can not assign Infinity to timing.endDelay function "function () {\n"use strict";\n\n    anim.effect.timing.endDelay = Infinity;\n  }" did not throw',
 
       'set endDelay negative Infinity':
-          'assert_throws: we can not assign negative Infinity to timing.endDelay function "function () {\n"use strict";\n\n    anim.effect.timing.endDe..." did not throw',
+          'assert_throws: we can not assign negative Infinity to timing.endDelay function "function () {\n"use strict";\n\n    anim.effect.timing.endDelay = -Infinity;\n  }" did not throw',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/fill.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/fill.html': {
       'set fill backwards':
           'anim.effect.getComputedTiming is not a function',
 
@@ -253,7 +389,7 @@ module.exports = {
           'anim.effect.getComputedTiming is not a function',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/getAnimations.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/getAnimations.html': {
       'when currentTime changed in duration:1000, delay: -500, endDelay: -500':
           'assert_equals: when currentTime 0 expected 0 but got 1',
 
@@ -270,7 +406,7 @@ module.exports = {
           'assert_equals: set iterations 10 expected (object) object "[object Object]" but got (undefined) undefined',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/getComputedStyle.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/getComputedStyle.html': {
       'change currentTime when fill forwards and endDelay is negative':
           'assert_equals: set currentTime same as endTime expected "0" but got "0.5"',
 
@@ -278,15 +414,15 @@ module.exports = {
           'assert_equals: set currentTime just a little before duration expected "0.0001" but got "0"',
 
       'changed duration immediately updates its computed styles':
-          'FLAKY_TEST_RESULT',
+          'assert_equals: set double duration expected "0.5" but got "0.005"',
 
       'changed iterations immediately updates its computed styles':
-          'FLAKY_TEST_RESULT',
+          'assert_equals: set 2 iterations expected "0" but got "0.01"',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/iterationStart.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/iterationStart.html': {
       'Test invalid iterationStart value':
-          'assert_throws: function "function () {\n"use strict";\n\n                  anim.effec..." threw object "ReferenceError: timing is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n                  anim.effect.timing.iterationStart = -1;\n                }" threw object "ReferenceError: timing is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Test that changing the iterationStart affects computed timing during the active phase':
           'anim.effect.getComputedTiming is not a function',
@@ -298,7 +434,7 @@ module.exports = {
           'anim.effect.getComputedTiming is not a function',
     },
 
-    'test/web-platform-tests/web-animations/animation-effect-timing/iterations.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/iterations.html': {
       'set iterations 2':
           'anim.effect.getComputedTiming is not a function',
 
@@ -306,29 +442,7 @@ module.exports = {
           'anim.effect.getComputedTiming is not a function',
     },
 
-    'test/web-platform-tests/web-animations/animation-model/animation-types/discrete-animation.html': {
-      'Test animating discrete values':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test discrete animation is used when interpolation fails':
-          'anim.effect.getComputedTiming is not a function',
-    },
-
-    'test/web-platform-tests/web-animations/animation-model/animation-types/not-animatable.html': {
-      '\'display\' property cannot be animated using a keyframe sequence':
-          'assert_false: Initial keyframe should not have the \'display\' property expected false got true',
-
-      '\'display\' property cannot be animated using property-indexed notation':
-          'assert_equals: Animation specified using property-indexed notation but consisting of only non-animatable properties should not contain any keyframes expected 0 but got 2',
-
-      'CSS animations and CSS transitions properties cannot be animated using a sequence of keyframes':
-          'assert_array_equals: Initial keyframe should not contain any properties other than the default keyframe properties lengths differ, expected 3 got 14',
-
-      'CSS animations and CSS transitions properties cannot be animated using property-indexed notation':
-          'assert_equals: Animation specified using property-indexed notation but consisting of only non-animatable properties should not contain any keyframes expected 0 but got 26',
-    },
-
-    'test/web-platform-tests/web-animations/animation-timeline/document-timeline.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationTimeline/document-timeline.html': {
       'document.timeline.currentTime liveness tests':
           'assert_true: document.timeline.currentTime increases between script blocks expected true got false',
 
@@ -336,7 +450,7 @@ module.exports = {
           'assert_true: document.timeline.currentTime is positive expected true got false',
     },
 
-    'test/web-platform-tests/web-animations/animation-timeline/idlharness.html': {
+    'test/web-platform-tests/web-animations/interfaces/AnimationTimeline/idlharness.html': {
       'AnimationTimeline interface object length':
           'assert_own_property: self does not have own property "AnimationTimeline" expected property "AnimationTimeline" missing',
 
@@ -380,117 +494,7 @@ module.exports = {
           'assert_equals: class string of document.timeline expected "[object DocumentTimeline]" but got "[object Object]"',
     },
 
-    'test/web-platform-tests/web-animations/animation/cancel.html': {
-      'After cancelling an animation, it can still be seeked':
-          'assert_equals: margin-left style is updated when cancelled animation is seeked expected "50px" but got "0px"',
-
-      'Animated style is cleared after calling Animation.cancel()':
-          'assert_not_equals: transform style is animated before cancelling got disallowed value "none"',
-    },
-
-    'test/web-platform-tests/web-animations/animation/finish.html': {
-      'Test exceptions when finishing infinite animation':
-          'assert_throws: function "function () {\n"use strict";\n\n    animation.finish();\n  }" did not throw',
-
-      'Test exceptions when finishing non-running animation':
-          'assert_throws: function "function () {\n"use strict";\n\n    animation.finish();\n  }" did not throw',
-
-      'Test finish() resolves finished promise synchronously with an animation without a target':
-          'KeyframeEffectReadOnly is not defined',
-
-      'Test finish() while pause-pending with negative playbackRate':
-          'assert_equals: The start time of a pause-pending animation should be set after calling finish() expected (undefined) undefined but got (number) 100000',
-
-      'Test finish() while pause-pending with positive playbackRate':
-          'assert_approx_equals: The start time of a pause-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
-
-      'Test finish() while paused':
-          'assert_equals: The play state of a paused animation should become "finished" after finish() is called expected "finished" but got "paused"',
-
-      'Test finish() while play-pending':
-          'assert_approx_equals: The start time of a play-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
-
-      'Test finishing of animation with a current time past the effect end':
-          'animation.effect.getComputedTiming is not a function',
-
-      'Test normally finished animation resolves finished promise synchronously with an animation without a target':
-          'KeyframeEffectReadOnly is not defined',
-    },
-
-    'test/web-platform-tests/web-animations/animation/finished.html': {
-      'Test finished promise changes for animation duration changes':
-          'assert_equals: currentTime should be unchanged when duration shortened expected 50000 but got 25000',
-
-      'Test finished promise is not resolved once the animation falls out finished state even though the current finished promise is generated soon after animation state became finished':
-          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
-
-      'Test finished promise is not resolved when the animation falls out finished state immediately':
-          'assert_unreached: Animation.finished should not be resolved Reached unreachable code',
-
-      'cancelling an already-finished animation replaces the finished promise':
-          'assert_not_equals: A new finished promise should be created when cancelling a finished animation got disallowed value object "[object Promise]"',
-
-      'cancelling an idle animation still replaces the finished promise':
-          'assert_not_equals: A redundant call to cancel() should still generate a new finished promise got disallowed value object "[object Promise]"',
-    },
-
-    'test/web-platform-tests/web-animations/animation/oncancel.html': {
-      'oncancel event is fired when animation.cancel() is called.':
-          'FLAKY_TEST_RESULT',
-    },
-
-    'test/web-platform-tests/web-animations/animation/onfinish.html': {
-      'onfinish event is fired when animation.finish() is called':
-          'FLAKY_TEST_RESULT',
-    },
-
-    'test/web-platform-tests/web-animations/animation/pause.html': {
-      'pause() from idle':
-          'assert_equals: currentTime is set to 0 expected (number) 0 but got (object) null',
-
-      'pause() from idle with a negative playbackRate':
-          'assert_equals: currentTime is set to the effect end expected (number) 1000000 but got (object) null',
-
-      'pause() from idle with a negative playbackRate and endless effect':
-          'assert_throws: Expect InvalidStateError exception on calling pause() from idle with a negative playbackRate and infinite-duration animation function "function () {\n"use strict";\n animation.pause(); }" did not throw',
-    },
-
-    'test/web-platform-tests/web-animations/animation/play.html': {
-      'play() throws when seeking an infinite-duration animation played in reverse':
-          'assert_throws: Expected InvalidStateError exception on calling play() with a negative playbackRate and infinite-duration animation function "function () {\n"use strict";\n animation.play(); }" did not throw',
-    },
-
-    'test/web-platform-tests/web-animations/animation/playState.html': {
-      'Animation.playState is \'paused\' after cancelling an animation, seeking it makes it paused':
-          'assert_equals: After seeking an idle animation, it is effectively paused expected "paused" but got "idle"',
-    },
-
-    'test/web-platform-tests/web-animations/animation/playbackRate.html': {
-      'Test the effect of setting playbackRate while playing animation':
-          'FLAKY_TEST_RESULT',
-    },
-
-    'test/web-platform-tests/web-animations/animation/reverse.html': {
-      'reverse() when playbackRate < 0 and currentTime < 0':
-          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime < 0 expected 0 but got -200000',
-
-      'reverse() when playbackRate < 0 and currentTime < 0 and the target effect end is positive infinity':
-          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime < 0 and the target effect is positive infinity expected 0 but got -200000',
-
-      'reverse() when playbackRate < 0 and currentTime > effect end':
-          'assert_equals: reverse() should start playing from the start of animation time if the playbackRate < 0 and the currentTime > effect end expected 0 but got 200000',
-
-      'reverse() when playbackRate > 0 and currentTime < 0':
-          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime < 0 expected 100000 but got -200000',
-
-      'reverse() when playbackRate > 0 and currentTime < 0 and the target effect end is positive infinity':
-          'assert_throws: reverse() should throw InvalidStateError if the playbackRate > 0 and the currentTime < 0 and the target effect is positive infinity function "function () {\n"use strict";\n animation.reverse(); }" did not throw',
-
-      'reverse() when playbackRate > 0 and currentTime > effect end':
-          'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime > effect end expected 100000 but got 200000',
-    },
-
-    'test/web-platform-tests/web-animations/document/getAnimations.html': {
+    'test/web-platform-tests/web-animations/interfaces/Document/getAnimations.html': {
       'Test document.getAnimations for non-animated content':
           'document.getAnimations is not a function',
 
@@ -504,93 +508,93 @@ module.exports = {
           'document.getAnimations is not a function',
     },
 
-    'test/web-platform-tests/web-animations/keyframe-effect/constructor.html': {
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/constructor.html': {
       'Invalid KeyframeEffectReadOnly option by -Infinity':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by NaN':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a NaN duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a NaN iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a blank easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a multi-value easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a negative Infinity duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a negative Infinity iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a negative duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a negative iterations':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a negative value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a string duration':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by a variable easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by an \'inherit\' easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by an \'initial\' easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid KeyframeEffectReadOnly option by an unrecognized easing':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target,\n                                 { left: ["10px", "20px"] },\n                                 stest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'Invalid easing [a blank easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
 
       'Invalid easing [a multi-value easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
 
       'Invalid easing [a variable easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
 
       'Invalid easing [an \'inherit\' easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
 
       'Invalid easing [an \'initial\' easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
 
       'Invalid easing [an unrecognized easing] in keyframe sequence should be thrown':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "TypeError" ("TypeError")',
 
       'KeyframeEffect constructor creates an AnimationEffectTiming timing object':
           'assert_equals: expected "[object KeyframeEffect]" but got "[object Object]"',
 
       'KeyframeEffectReadOnly constructor throws with a keyframe sequence with an invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'KeyframeEffectReadOnly constructor throws with keyframes not loosely sorted by offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'KeyframeEffectReadOnly constructor throws with keyframes with an invalid composite value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'KeyframeEffectReadOnly constructor throws with keyframes with an out-of-bounded negative offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'KeyframeEffectReadOnly constructor throws with keyframes with an out-of-bounded positive offset':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'KeyframeEffectReadOnly constructor throws with property-indexed keyframes with an invalid easing value':
-          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectRead..." threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
+          'assert_throws: function "function () {\n"use strict";\n\n      new KeyframeEffectReadOnly(target, subtest.input);\n    }" threw object "ReferenceError: KeyframeEffectReadOnly is not defined" ("ReferenceError") expected object "[object Object]" ("TypeError")',
 
       'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where greater shorthand precedes lesser shorthand':
           'KeyframeEffectReadOnly is not defined',
@@ -604,6 +608,12 @@ module.exports = {
       'a KeyframeEffectReadOnly can be constructed with a keyframe sequence where shorthand precedes longhand':
           'KeyframeEffectReadOnly is not defined',
 
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with a CSS variable reference':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with a CSS variable reference in a shorthand property':
+          'KeyframeEffectReadOnly is not defined',
+
       'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with different composite values, but the same composite value for a given offset':
           'KeyframeEffectReadOnly is not defined',
 
@@ -614,6 +624,9 @@ module.exports = {
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with duplicate values for offsets 0 and 1':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a keyframe sequence with repeated values at offset 1 with different easings':
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly can be constructed with a one property keyframe sequence with all omitted offsets':
@@ -655,10 +668,13 @@ module.exports = {
       'a KeyframeEffectReadOnly can be constructed with a one shorthand property two value property-indexed keyframes specification':
           'KeyframeEffectReadOnly is not defined',
 
-      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with an invalid value':
+      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with a CSS variable reference':
           'KeyframeEffectReadOnly is not defined',
 
-      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with repeated values at offset 0 with different easings':
+      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with a CSS variable reference in a shorthand property':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a property-indexed keyframes specification with an invalid value':
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly can be constructed with a single keyframe sequence with omitted offsets':
@@ -673,13 +689,13 @@ module.exports = {
       'a KeyframeEffectReadOnly can be constructed with a two property four keyframe sequence':
           'KeyframeEffectReadOnly is not defined',
 
+      'a KeyframeEffectReadOnly can be constructed with a two property keyframe sequence where one property is missing from the first keyframe':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly can be constructed with a two property keyframe sequence where one property is missing from the last keyframe':
+          'KeyframeEffectReadOnly is not defined',
+
       'a KeyframeEffectReadOnly can be constructed with a two property keyframe sequence with some omitted offsets':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification where one property is missing from the first keyframe':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification where one property is missing from the last keyframe':
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly can be constructed with a two property property-indexed keyframes specification with different numbers of values':
@@ -733,6 +749,12 @@ module.exports = {
       'a KeyframeEffectReadOnly constructed with a keyframe sequence where shorthand precedes longhand roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence with a CSS variable reference in a shorthand property roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence with a CSS variable reference roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
       'a KeyframeEffectReadOnly constructed with a keyframe sequence with different composite values, but the same composite value for a given offset roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
@@ -743,6 +765,9 @@ module.exports = {
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly constructed with a keyframe sequence with duplicate values for offsets 0 and 1 roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a keyframe sequence with repeated values at offset 1 with different easings roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly constructed with a one property keyframe sequence with all omitted offsets roundtrips':
@@ -784,10 +809,13 @@ module.exports = {
       'a KeyframeEffectReadOnly constructed with a one shorthand property two value property-indexed keyframes specification roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
-      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with an invalid value roundtrips':
+      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with a CSS variable reference in a shorthand property roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
-      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with repeated values at offset 0 with different easings roundtrips':
+      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with a CSS variable reference roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a property-indexed keyframes specification with an invalid value roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly constructed with a single keyframe sequence with omitted offsets roundtrips':
@@ -802,13 +830,13 @@ module.exports = {
       'a KeyframeEffectReadOnly constructed with a two property four keyframe sequence roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
+      'a KeyframeEffectReadOnly constructed with a two property keyframe sequence where one property is missing from the first keyframe roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
+      'a KeyframeEffectReadOnly constructed with a two property keyframe sequence where one property is missing from the last keyframe roundtrips':
+          'KeyframeEffectReadOnly is not defined',
+
       'a KeyframeEffectReadOnly constructed with a two property keyframe sequence with some omitted offsets roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification where one property is missing from the first keyframe roundtrips':
-          'KeyframeEffectReadOnly is not defined',
-
-      'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification where one property is missing from the last keyframe roundtrips':
           'KeyframeEffectReadOnly is not defined',
 
       'a KeyframeEffectReadOnly constructed with a two property property-indexed keyframes specification with different numbers of values roundtrips':
@@ -848,7 +876,7 @@ module.exports = {
           'KeyframeEffectReadOnly is not defined',
     },
 
-    'test/web-platform-tests/web-animations/keyframe-effect/getComputedTiming.html': {
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/getComputedTiming.html': {
       'getComputedTiming().activeDuration for a non-zero duration and default iteration count':
           'KeyframeEffectReadOnly is not defined',
 
@@ -958,116 +986,221 @@ module.exports = {
           'KeyframeEffectReadOnly is not defined',
     },
 
-    'test/web-platform-tests/web-animations/keyframe-effect/keyframe-handling.html': {
-      'Overlapping keyframes at 0 and 1 use the appropriate value when the progress is outside the range [0, 1]':
-          'assert_equals: When progress is negative, the first keyframe with a 0 offset should be used expected "0" but got "0.151"',
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html': {
+      'non-animatable property \'animation\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animation\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationDelay\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationDelay\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationDirection\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationDirection\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationDuration\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationDuration\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationFillMode\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationFillMode\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationIterationCount\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationIterationCount\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationName\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationName\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationPlayState\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationPlayState\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationTimingFunction\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'animationTimingFunction\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'display\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'display\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transition\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transition\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionDelay\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionDelay\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionDuration\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionDuration\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionProperty\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionProperty\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionTimingFunction\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'transitionTimingFunction\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'unsupportedProperty\' is not accessed when using a keyframe sequence':
+          'KeyframeEffectReadOnly is not defined',
+
+      'non-animatable property \'unsupportedProperty\' is not accessed when using a property-indexed keyframe object':
+          'KeyframeEffectReadOnly is not defined',
     },
 
-    'test/web-platform-tests/web-animations/keyframe-effect/setFrames.html': {
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/setKeyframes.html': {
       'Keyframes can be replaced with a keyframe sequence where greater shorthand precedes lesser shorthand':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a keyframe sequence where lesser shorthand precedes greater shorthand':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a keyframe sequence where longhand precedes shorthand':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a keyframe sequence where shorthand precedes longhand':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
+
+      'Keyframes can be replaced with a keyframe sequence with a CSS variable reference':
+          'effect.setKeyframes is not a function',
+
+      'Keyframes can be replaced with a keyframe sequence with a CSS variable reference in a shorthand property':
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a keyframe sequence with different composite values, but the same composite value for a given offset':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a keyframe sequence with different easing values, but the same easing value for a given offset':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a keyframe sequence with duplicate values for a given interior offset':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a keyframe sequence with duplicate values for offsets 0 and 1':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
+
+      'Keyframes can be replaced with a keyframe sequence with repeated values at offset 1 with different easings':
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property keyframe sequence with all omitted offsets':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property keyframe sequence with some omitted offsets':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property one keyframe sequence':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property one non-array value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property one value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property two keyframe sequence':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property two keyframe sequence that needs to stringify its values':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property two value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property two value property-indexed keyframes specification that needs to stringify its values':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property two value property-indexed keyframes specification where the first value is invalid':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one property two value property-indexed keyframes specification where the second value is invalid':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one shorthand property two keyframe sequence':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a one shorthand property two value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
+
+      'Keyframes can be replaced with a property-indexed keyframes specification with a CSS variable reference':
+          'effect.setKeyframes is not a function',
+
+      'Keyframes can be replaced with a property-indexed keyframes specification with a CSS variable reference in a shorthand property':
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a property-indexed keyframes specification with an invalid value':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a property-indexed keyframes specification with repeated values at offset 0 with different easings':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a single keyframe sequence with omitted offsets':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a two property (a shorthand and one of its component longhands) two keyframe sequence':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a two property (one shorthand and one of its longhand components) two value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a two property four keyframe sequence':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
+
+      'Keyframes can be replaced with a two property keyframe sequence where one property is missing from the first keyframe':
+          'effect.setKeyframes is not a function',
+
+      'Keyframes can be replaced with a two property keyframe sequence where one property is missing from the last keyframe':
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a two property keyframe sequence with some omitted offsets':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a two property property-indexed keyframes specification where one property is missing from the first keyframe':
-          'effect.setFrames is not a function',
-
-      'Keyframes can be replaced with a two property property-indexed keyframes specification where one property is missing from the last keyframe':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a two property property-indexed keyframes specification with different numbers of values':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a two property two keyframe sequence':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with a two property two value property-indexed keyframes specification':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
 
       'Keyframes can be replaced with an empty keyframe':
-          'effect.setFrames is not a function',
+          'effect.setKeyframes is not a function',
     },
 
-    'test/web-platform-tests/web-animations/keyframe-effect/setTarget.html': {
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/setTarget.html': {
       'Test setting target from a valid target to another target':
           'assert_equals: Value of 1st element (currently not targeted) after changing the effect target expected "10px" but got "50px"',
 
@@ -1076,11 +1209,6 @@ module.exports = {
 
       'Test setting target from null to a valid target':
           'assert_equals: Value at 50% progress after setting new target expected "50px" but got "10px"',
-    },
-
-    'test/web-platform-tests/web-animations/timing-model/animation-effects/active-time.html': {
-      'Test progress during before and after phase when fill is none':
-          'anim.effect.getComputedTiming is not a function',
     },
 
     'test/web-platform-tests/web-animations/timing-model/animation-effects/current-iteration.html': {
@@ -1198,112 +1326,79 @@ module.exports = {
 
     'test/web-platform-tests/web-animations/timing-model/animation-effects/simple-iteration-progress.html': {
       'Test fractional iterations: iterations:3.5 iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test fractional iterations: iterations:3.5 iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 1',
 
       'Test fractional iterations: iterations:3.5 iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test fractional iterations: iterations:3.5 iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test fractional iterations: iterations:3.5 iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 0',
 
       'Test fractional iterations: iterations:3.5 iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 1',
 
       'Test fractional iterations: iterations:3.5 iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test fractional iterations: iterations:3.5 iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 1',
 
       'Test fractional iterations: iterations:3.5 iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test infinity iterations: iterations:Infinity iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test infinity iterations: iterations:Infinity iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test infinity iterations: iterations:Infinity iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test infinity iterations: iterations:Infinity iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test infinity iterations: iterations:Infinity iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 1',
 
       'Test infinity iterations: iterations:Infinity iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 1',
 
       'Test infinity iterations: iterations:Infinity iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test infinity iterations: iterations:Infinity iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test infinity iterations: iterations:Infinity iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test integer iterations: iterations:3 iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test integer iterations: iterations:3 iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 0',
 
       'Test integer iterations: iterations:3 iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
-
-      'Test integer iterations: iterations:3 iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 1',
 
       'Test integer iterations: iterations:3 iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test zero iterations: iterations:0 iterationStart:0 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test zero iterations: iterations:0 iterationStart:0 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test zero iterations: iterations:0 iterationStart:0 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test zero iterations: iterations:0 iterationStart:2.5 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 0',
 
       'Test zero iterations: iterations:0 iterationStart:2.5 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 0',
 
       'Test zero iterations: iterations:0 iterationStart:2.5 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0.5 but got 1',
 
       'Test zero iterations: iterations:0 iterationStart:3 duration:0 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test zero iterations: iterations:0 iterationStart:3 duration:100 delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
 
       'Test zero iterations: iterations:0 iterationStart:3 duration:Infinity delay:1 fill:both':
-          'anim.effect.getComputedTiming is not a function',
+          'assert_equals: expected 0 but got 1',
     },
 
     'test/web-platform-tests/web-animations/timing-model/animations/set-the-animation-start-time.html': {

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -229,12 +229,12 @@ module.exports = {
 
     'test/web-platform-tests/web-animations/interfaces/Animation/oncancel.html': {
       'oncancel event is fired when animation.cancel() is called.':
-          'assert_equals: event.timelineTime should equal to the animation timeline when finished promise is rejected expected (undefined) undefined but got (number) 1111.6200000000001',
+          'FLAKY_TEST_RESULT',
     },
 
     'test/web-platform-tests/web-animations/interfaces/Animation/onfinish.html': {
       'onfinish event is fired when animation.finish() is called':
-          'assert_equals: event.timelineTime should equal to the animation timeline when finished promise is resolved expected (undefined) undefined but got (number) 1079.882351',
+          'FLAKY_TEST_RESULT',
     },
 
     'test/web-platform-tests/web-animations/interfaces/Animation/pause.html': {
@@ -260,7 +260,7 @@ module.exports = {
 
     'test/web-platform-tests/web-animations/interfaces/Animation/playbackRate.html': {
       'Test the effect of setting playbackRate while playing animation':
-          'assert_approx_equals: animation.currentTime should be the same speed as timeline now. expected 16.114772999999786 +/- 0.001 but got 0',
+          'FLAKY_TEST_RESULT',
     },
 
     'test/web-platform-tests/web-animations/interfaces/Animation/reverse.html': {
@@ -360,7 +360,7 @@ module.exports = {
 
     'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/endDelay.html': {
       'onfinish event is fired currentTime is after endTime':
-          'assert_equals: receivedEvents[0].timelineTime should equal to the animation timeline when finished promise is resolved expected 1173.360423 but got 1190.491128',
+          'FLAKY_TEST_RESULT',
 
       'set endDelay -1000':
           'anim.effect.getComputedTiming is not a function',
@@ -414,10 +414,10 @@ module.exports = {
           'assert_equals: set currentTime just a little before duration expected "0.0001" but got "0"',
 
       'changed duration immediately updates its computed styles':
-          'assert_equals: set double duration expected "0.5" but got "0.005"',
+          'FLAKY_TEST_RESULT',
 
       'changed iterations immediately updates its computed styles':
-          'assert_equals: set 2 iterations expected "0" but got "0.01"',
+          'FLAKY_TEST_RESULT',
     },
 
     'test/web-platform-tests/web-animations/interfaces/AnimationEffectTiming/iterationStart.html': {


### PR DESCRIPTION
This change enables testing a subset of web-platform-tests/web-animations with the web-animations target.

This change builds upon https://github.com/web-animations/web-animations-next/pull/465.