### PR TITLE
Throw InvalidStateError when calling play() on a finished, reversed, infinite duration animation

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -116,7 +116,10 @@
       this._playbackRate = value;
       this._startTime = null;
       if (this.playState != 'paused' && this.playState != 'idle') {
-        this.play();
+        this._finishedFlag = false;
+        this._idle = false;
+        this._ensureAlive();
+        scope.invalidateEffects();
       }
       if (oldCurrentTime != null) {
         this.currentTime = oldCurrentTime;
@@ -141,7 +144,15 @@
     play: function() {
       this._paused = false;
       if (this._isFinished || this._idle) {
-        this._currentTime = this._playbackRate > 0 ? 0 : this._totalDuration;
+        if (this._playbackRate >= 0) {
+          this._currentTime = 0;
+        } else if (this._totalDuration < Infinity) {
+          this._currentTime = this._totalDuration;
+        } else {
+          throw new DOMException(
+              'Unable to rewind negative playback rate animation with infinite duration',
+              'InvalidStateError');
+        }
         this._startTime = null;
       }
       this._finishedFlag = false;

--- a/src/web-animations-next-animation.js
+++ b/src/web-animations-next-animation.js
@@ -276,9 +276,6 @@
       this._forEachChild(function(childAnimation) {
         childAnimation.playbackRate = value;
       });
-      if (this.playState != 'paused' && this.playState != 'idle') {
-        this.play();
-      }
       if (oldCurrentTime !== null) {
         this.currentTime = oldCurrentTime;
       }

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -176,10 +176,10 @@ module.exports = {
           'KeyframeEffectReadOnly is not defined',
 
       'Test finish() while pause-pending with negative playbackRate':
-          'assert_equals: The start time of a pause-pending animation should be set after calling finish() expected (undefined) undefined but got (number) 100000',
+          'assert_equals: The play state of a pause-pending animation should become "finished" after finish() is called expected "finished" but got "paused"',
 
       'Test finish() while pause-pending with positive playbackRate':
-          'assert_approx_equals: The start time of a pause-pending animation should be set after calling finish() expected NaN +/- 0.0005 but got 0',
+          'assert_equals: The play state of a pause-pending animation should become "finished" after finish() is called expected "finished" but got "paused"',
 
       'Test finish() while paused':
           'assert_equals: The play state of a paused animation should become "finished" after finish() is called expected "finished" but got "paused"',

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -232,11 +232,6 @@ module.exports = {
           'assert_throws: Expect InvalidStateError exception on calling pause() from idle with a negative playbackRate and infinite-duration animation function "function () {\n"use strict";\n animation.pause(); }" did not throw',
     },
 
-    'test/web-platform-tests/web-animations/interfaces/Animation/play.html': {
-      'play() throws when seeking an infinite-duration animation played in reverse':
-          'assert_throws: Expected InvalidStateError exception on calling play() with a negative playbackRate and infinite-duration animation function "function () {\n"use strict";\n animation.play(); }" did not throw',
-    },
-
     'test/web-platform-tests/web-animations/interfaces/Animation/playState.html': {
       'Animation.playState is \'paused\' after cancelling an animation, seeking it makes it paused':
           'assert_equals: After seeking an idle animation, it is effectively paused expected "paused" but got "idle"',
@@ -259,9 +254,6 @@ module.exports = {
 
       'reverse() when playbackRate > 0 and currentTime < 0':
           'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime < 0 expected 100000 but got -200000',
-
-      'reverse() when playbackRate > 0 and currentTime < 0 and the target effect end is positive infinity':
-          'assert_throws: reverse() should throw InvalidStateError if the playbackRate > 0 and the currentTime < 0 and the target effect is positive infinity function "function () {\n"use strict";\n animation.reverse(); }" did not throw',
 
       'reverse() when playbackRate > 0 and currentTime > effect end':
           'assert_equals: reverse() should start playing from the animation effect end if the playbackRate > 0 and the currentTime > effect end expected 100000 but got 200000',


### PR DESCRIPTION
Relevant spec section:
https://w3c.github.io/web-animations/#playing-an-animation-section