### PR TITLE
Prevent cubic bezier from infinite-looping

### DIFF
--- a/src/timing-utilities.js
+++ b/src/timing-utilities.js
@@ -178,11 +178,11 @@
         return x;
       }
       var start = 0, end = 1;
-      while (1) {
+      while (start < end) {
         var mid = (start + end) / 2;
         function f(a, b, m) { return 3 * a * (1 - m) * (1 - m) * m + 3 * b * (1 - m) * m * m + m * m * m};
         var xEst = f(a, c, mid);
-        if (Math.abs(x - xEst) < 0.0001) {
+        if (Math.abs(x - xEst) < 0.00001) {
           return f(b, d, mid);
         }
         if (xEst < x) {
@@ -191,6 +191,7 @@
           end = mid;
         }
       }
+      return f(b, d, mid);
     }
   }
 

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -4,9 +4,6 @@ module.exports = {
     'test/web-platform-tests/web-animations/interfaces/Animation/constructor.html':
         'KeyframeEffectReadOnly is not defined causing the test to timeout.',
 
-    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/effect-easing.html':
-        'It seems to enter an infinite loop and halt the browser.',
-
     'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/effect-easing-steps.html':
         'It seems to enter an infinite loop and halt the browser.',
   },
@@ -858,6 +855,26 @@ module.exports = {
 
       'the KeyframeEffectReadOnly constructor reads keyframe properties in the expected order':
           'KeyframeEffectReadOnly is not defined',
+    },
+
+    'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/effect-easing.html': {
+      'effect easing produces values greater than 1 with keyframe easing cubic-bezier(0, 0, 0, 0)':
+          'assert_approx_equals: The left of the animation should be approximately 102.40666638411385 at 250ms expected 102.40666638411385 +/- 0.01 but got 100',
+
+      'effect easing produces values greater than 1 with keyframe easing cubic-bezier(1, 1, 1, 1)':
+          'assert_approx_equals: The left of the animation should be approximately 102.40666638411385 at 250ms expected 102.40666638411385 +/- 0.01 but got 100',
+
+      'effect easing produces negative values 1 with keyframe easing cubic-bezier(0, 0, 0, 0)':
+          'assert_approx_equals: The left of the animation should be approximately -29.501119758965654 at 250ms expected -29.501119758965654 +/- 0.01 but got 0',
+
+      'effect easing produces negative values 1 with keyframe easing cubic-bezier(1, 1, 1, 1)':
+          'assert_approx_equals: The left of the animation should be approximately -29.501119758965654 at 250ms expected -29.501119758965654 +/- 0.01 but got 0',
+
+      'effect easing produces values greater than 1 with keyframe easing producing values greater than 1':
+          'assert_approx_equals: The left of the animation should be approximately 101.9006796334848 at 240ms expected 101.9006796334848 +/- 0.01 but got 100',
+
+      'effect easing produces negative values with keyframe easing producing negative values':
+          'assert_approx_equals: The left of the animation should be approximately -16.589193103032184 at 10ms expected -16.589193103032184 +/- 0.01 but got 0',
     },
 
     'test/web-platform-tests/web-animations/interfaces/KeyframeEffect/getComputedTiming.html': {


### PR DESCRIPTION
An infinite loop in the cubic bezier function in src/timing-utilities.js was
causing us to skip interfaces/KeyframeEffect/effect-easing.html from the
web-platform-tests. This patch changes the loop condition to ensure it exits,
in line with the CubicBezier implementation in Chromium.

In order to achieve the accuracy required by the web-platform-tests
expectations, the epsilon value in the algorithm is also reduced by an order of
magnitude.