### PR TITLE
Make pause() on idle animations set their current time according to playbackRate

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -145,18 +145,21 @@
         return 'finished';
       return 'running';
     },
+    _quietlySeekToEnd: function() {
+      if (this._playbackRate >= 0) {
+        this._currentTime = 0;
+      } else if (this._totalDuration < Infinity) {
+        this._currentTime = this._totalDuration;
+      } else {
+        throw new DOMException(
+            'Unable to rewind negative playback rate animation with infinite duration',
+            'InvalidStateError');
+      }
+    },
     play: function() {
       this._paused = false;
       if (this._isFinished || this._idle) {
-        if (this._playbackRate >= 0) {
-          this._currentTime = 0;
-        } else if (this._totalDuration < Infinity) {
-          this._currentTime = this._totalDuration;
-        } else {
-          throw new DOMException(
-              'Unable to rewind negative playback rate animation with infinite duration',
-              'InvalidStateError');
-        }
+        this._quietlySeekToEnd();
         this._startTime = null;
       }
       this._finishedFlag = false;
@@ -167,6 +170,9 @@
     pause: function() {
       if (!this._isFinished && !this._paused && !this._idle) {
         this._currentTimePending = true;
+      } else if (this._idle) {
+        this._quietlySeekToEnd();
+        this._idle = false;
       }
       this._startTime = null;
       this._paused = true;

--- a/src/animation.js
+++ b/src/animation.js
@@ -145,7 +145,7 @@
         return 'finished';
       return 'running';
     },
-    _quietlySeekToEnd: function() {
+    _rewind: function() {
       if (this._playbackRate >= 0) {
         this._currentTime = 0;
       } else if (this._totalDuration < Infinity) {
@@ -159,7 +159,7 @@
     play: function() {
       this._paused = false;
       if (this._isFinished || this._idle) {
-        this._quietlySeekToEnd();
+        this._rewind();
         this._startTime = null;
       }
       this._finishedFlag = false;
@@ -171,7 +171,7 @@
       if (!this._isFinished && !this._paused && !this._idle) {
         this._currentTimePending = true;
       } else if (this._idle) {
-        this._quietlySeekToEnd();
+        this._rewind();
         this._idle = false;
       }
       this._startTime = null;

--- a/test/js/animation.js
+++ b/test/js/animation.js
@@ -511,8 +511,8 @@ suite('animation', function() {
     assert.equal(a.startTime, null);
     tick(1);
     a.pause();
-    assert.equal(a.playState, 'idle');
-    assert.equal(a.currentTime, null);
+    assert.equal(a.playState, 'paused');
+    assert.equal(a.currentTime, 0);
     assert.equal(a.startTime, null);
   });
   test('Animations ignore NaN times', function() {

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -1429,7 +1429,7 @@ module.exports = {
           'Animation with null timeline is not supported',
 
       'Setting the start time resolves a pending pause task':
-          'assert_equals: Animation is in pause-pending state expected "pending" but got "idle"',
+          'assert_equals: Animation is in pause-pending state expected "pending" but got "paused"',
 
       'Setting the start time updates the finished state':
           'assert_equals: Seeked to finished state using the startTime expected "finished" but got "idle"',

--- a/test/web-platform-tests-expectations.js
+++ b/test/web-platform-tests-expectations.js
@@ -214,13 +214,7 @@ module.exports = {
 
     'test/web-platform-tests/web-animations/interfaces/Animation/pause.html': {
       'pause() from idle':
-          'assert_equals: currentTime is set to 0 expected (number) 0 but got (object) null',
-
-      'pause() from idle with a negative playbackRate':
-          'assert_equals: currentTime is set to the effect end expected (number) 1000000 but got (object) null',
-
-      'pause() from idle with a negative playbackRate and endless effect':
-          'assert_throws: Expect InvalidStateError exception on calling pause() from idle with a negative playbackRate and infinite-duration animation function "function () {\n"use strict";\n animation.pause(); }" did not throw',
+          'assert_equals: initially pause-pending expected "pending" but got "paused"',
     },
 
     'test/web-platform-tests/web-animations/interfaces/Animation/playbackRate.html': {


### PR DESCRIPTION
This changes our behaviour for pause() on cancelled/idle animations to rewind the current time to the start of the animation.
https://w3c.github.io/web-animations/#pausing-an-animation-section