### PR TITLE
Disable native fallback during web-platform-tests

### DIFF
--- a/test/resources/testharnessreport.js
+++ b/test/resources/testharnessreport.js
@@ -406,6 +406,11 @@ function dump_test_results(tests, status) {
 }
 
 /* BEGIN WEB ANIMATIONS POLYFILL EXTRAS */
+
+// Disable native Web Animations fallback.
+// TODO(alancutter): Make this configurable in testing targets.
+Element.prototype.animate = null;
+
 // The path /base/polyfill.js is expected to be a proxy for the appropriate polyfill script configured in Karma.
 document.write('<script src="/base/polyfill.js"></script>');
 if (window.parent && parent.window.onTestharnessLoaded) {
@@ -413,6 +418,7 @@ if (window.parent && parent.window.onTestharnessLoaded) {
 } else {
   metadata_generator.setup();
 }
+
 /* END WEB ANIMATIONS POLYFILL EXTRAS */
 
 /* If the parent window has a testharness_properties object,


### PR DESCRIPTION
Now that Firefox has shipped Element.animate() the polyfill's web-animations-js target is effectively doing nothing during tests.
This change disables access to native's Element.animate() in tests so that the polyfill always provides its own implementation.